### PR TITLE
Refactor main widget to be a QStackedWidget

### DIFF
--- a/src/allencell_ml_segmenter/core/publisher.py
+++ b/src/allencell_ml_segmenter/core/publisher.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import List
 
-from allencell_ml_segmenter.core import Subscriber, Event
+from . import Subscriber, Event
 
 
 class Publisher(ABC):
@@ -20,7 +20,7 @@ class Publisher(ABC):
         for i in self._subscribers:
             i.handle_event(event)
 
-    def subscribe(self, subscriber):
+    def subscribe(self, subscriber: Subscriber):
         """
         subscribes a subscriber to this publisher
         """

--- a/src/allencell_ml_segmenter/widgets/__init__.py
+++ b/src/allencell_ml_segmenter/widgets/__init__.py
@@ -1,9 +1,7 @@
 from allencell_ml_segmenter.widgets.training_widget import TrainingWidget
-from allencell_ml_segmenter.widgets.main_widget import MainWidget
 from allencell_ml_segmenter.widgets.selection_widget import SelectionWidget
 
 __all__ = (
     "TrainingWidget",
-    "MainWidget",
     "SelectionWidget",
 )


### PR DESCRIPTION
@hughes036  and I refactored what we had further.

- We dont have to implement page switching since QStackedWidget natively supports it. 
- We further decoupled our view from the main widget.
- More changes so that main widget follows pub/sub model.