### PR TITLE
Publisher API allows subscribing to specified evt

### DIFF
--- a/src/allencell_ml_segmenter/_tests/core/test_publisher.py
+++ b/src/allencell_ml_segmenter/_tests/core/test_publisher.py
@@ -1,5 +1,6 @@
 import pytest
 from allencell_ml_segmenter.core.publisher import Publisher, Event
+from allencell_ml_segmenter._tests.fakes.fake_event_handler import FakeEventHandler
 from allencell_ml_segmenter._tests.fakes.fake_subscriber import FakeSubscriber
 
 
@@ -10,20 +11,53 @@ def publisher():
 
 def test_pub_dispatch(publisher):
     subscriber = FakeSubscriber()
-    publisher.subscribe(subscriber)
+    publisher.subscribe(Event.TRAINING, subscriber)
 
     publisher.dispatch(Event.TRAINING)
 
     assert subscriber.handled_event == Event.TRAINING
 
 
-def test_pub_dispatch_multiple(publisher):
+def test_pub_dispatch_explicit_handler(publisher: Publisher):
+    subscriber = FakeSubscriber()
+    fake_event_handler = FakeEventHandler()
+    publisher.subscribe(Event.TRAINING, subscriber, fake_event_handler.handle)
+
+    # ACT
+    publisher.dispatch(Event.TRAINING)
+
+    assert fake_event_handler.is_handled()
+
+
+def test_pub_dispatch_multiple(publisher: Publisher):
     subscriber1 = FakeSubscriber()
     subscriber2 = FakeSubscriber()
-    publisher.subscribe(subscriber1)
-    publisher.subscribe(subscriber2)
+    publisher.subscribe(Event.TRAINING, subscriber1)
+    publisher.subscribe(Event.TRAINING, subscriber2)
 
     publisher.dispatch(Event.TRAINING)
 
     assert subscriber1.handled_event == Event.TRAINING
     assert subscriber2.handled_event == Event.TRAINING
+
+
+def test_pub_unsubscribe(publisher: Publisher):
+    subscriber = FakeSubscriber()
+
+    # ARRANGE
+    publisher.subscribe(Event.TRAINING, subscriber)
+    publisher.unsubscribe(Event.TRAINING, subscriber)
+
+    # ACT
+    publisher.dispatch(Event.TRAINING)
+
+    assert subscriber.handled_event is None
+
+
+def test_pub_unsubscribe_unknown(publisher: Publisher):
+    subscriber = FakeSubscriber()
+
+    # ACT
+    publisher.unsubscribe(Event.TRAINING, subscriber)
+
+    assert 1 == 1  # no error raised

--- a/src/allencell_ml_segmenter/_tests/fakes/fake_event_handler.py
+++ b/src/allencell_ml_segmenter/_tests/fakes/fake_event_handler.py
@@ -1,0 +1,15 @@
+from allencell_ml_segmenter.core.event import Event
+
+
+class FakeEventHandler():
+    """
+    """
+
+    def __init__(self):
+        self.handled = False
+
+    def handle(self, event: Event):
+        self.handled = True
+
+    def is_handled(self):
+        return self.handled

--- a/src/allencell_ml_segmenter/_tests/fakes/fake_subscriber.py
+++ b/src/allencell_ml_segmenter/_tests/fakes/fake_subscriber.py
@@ -2,11 +2,9 @@ from allencell_ml_segmenter.core.subscriber import Subscriber
 from allencell_ml_segmenter.core.event import Event
 
 
-# Testing publishers with this mock subscriber class
-# that implements handle_event
 class FakeSubscriber(Subscriber):
     """
-    Testing publishers with this mock subscriber class
+    Testing publishers with this fake subscriber class
     that implements handle_event
     """
 

--- a/src/allencell_ml_segmenter/_tests/models/test_main_model.py
+++ b/src/allencell_ml_segmenter/_tests/models/test_main_model.py
@@ -16,13 +16,8 @@ def fake_subscriber():
     return FakeSubscriber()
 
 
-def test_init(main_model):
-    assert main_model._current_view == None
-    assert len(main_model._subscribers) == 0
-
-
 def test_get_current_view(main_model):
-    assert main_model.get_current_view() == None
+    assert main_model.get_current_view() is None
     mock_view = Mock(spec=View)
     main_model._current_view = mock_view
 
@@ -32,14 +27,7 @@ def test_get_current_view(main_model):
 def test_set_current_view(main_model, fake_subscriber):
     # set a mock views
     mock_view = Mock(spec=View)
-    main_model.set_current_view(mock_view)
-    assert main_model._current_view == mock_view
-    # set subscriber
-    assert len(main_model._subscribers) == 0
-    main_model.subscribe(fake_subscriber)
-
+    main_model.subscribe(Event.CHANGE_VIEW, fake_subscriber)
     main_model.set_current_view(mock_view)
 
-    assert main_model._current_view == mock_view
-    assert len(main_model._subscribers) == 1
     assert fake_subscriber.handled_event == Event.CHANGE_VIEW

--- a/src/allencell_ml_segmenter/_tests/models/test_training_model.py
+++ b/src/allencell_ml_segmenter/_tests/models/test_training_model.py
@@ -11,7 +11,7 @@ def training_model():
 
 def test_set_model_training(training_model):
     subscriber = FakeSubscriber()
-    training_model.subscribe(subscriber)
+    training_model.subscribe(Event.TRAINING, subscriber)
 
     training_model.set_model_training(True)
 

--- a/src/allencell_ml_segmenter/_tests/views/test_training_view.py
+++ b/src/allencell_ml_segmenter/_tests/views/test_training_view.py
@@ -28,10 +28,16 @@ def test_model_property(training_view, main_model):
     assert training_view._main_model == main_model
 
 
-def test_handle_event_training_selected(training_view, main_model, qtbot):
-    training_view.handle_event(Event.TRAINING_SELECTED)
+def integration_test_handle_event_training_selected(training_view):
+    # ARRANGE
+    model = MainModel()
+    TrainingView(model)
 
-    main_model.set_current_view.assert_called_once_with(training_view)
+    # ACT
+    model.dispatch(Event.TRAINING_SELECTED)
+
+    # ASSERT
+    model.set_current_view.assert_called_once_with(training_view)
 
 
 def test_back_to_main(training_view, main_model, qtbot):

--- a/src/allencell_ml_segmenter/views/training_view.py
+++ b/src/allencell_ml_segmenter/views/training_view.py
@@ -20,7 +20,9 @@ class TrainingView(View, Subscriber):
 
         # models
         self._main_model = main_model
-        self._main_model.subscribe(self)
+        self._main_model.subscribe(Event.TRAINING_SELECTED,
+                                   self,
+                                   lambda e: self._main_model.set_current_view(self))
 
         # init widget and connect slots
         widget = TrainingWidget()
@@ -29,10 +31,7 @@ class TrainingView(View, Subscriber):
 
     def handle_event(self, event: Event) -> None:
         """
-        Handles Events from the Training Model
         """
-        if event == Event.TRAINING_SELECTED:
-            self._main_model.set_current_view(self)
 
     def back_to_main(self) -> None:
         """

--- a/src/allencell_ml_segmenter/widgets/main_widget.py
+++ b/src/allencell_ml_segmenter/widgets/main_widget.py
@@ -40,7 +40,7 @@ class MainWidget(QStackedWidget, Subscriber, metaclass=MainMeta):
 
         # Model
         self.model: MainModel = MainModel()
-        self.model.subscribe(self)
+        self.model.subscribe(Event.CHANGE_VIEW, self)
 
         # Dictionaries of views to index values
         self.view_to_index = dict()

--- a/src/allencell_ml_segmenter/widgets/selection_widget.py
+++ b/src/allencell_ml_segmenter/widgets/selection_widget.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import (
 from allencell_ml_segmenter.core.event import Event
 from allencell_ml_segmenter.models.main_model import MainModel
 
+
 class SelectionWidget(QWidget):
     """
     A sample widget with two buttons for selecting between training and prediction views.
@@ -34,7 +35,7 @@ class SelectionWidget(QWidget):
 
         # models
         self.model = model
-        self.model.subscribe(self)
+        self.model.subscribe(Event.MAIN_SELECTED, self)
 
     def handle_event(self, event: Event) -> None:
         if event == Event.MAIN_SELECTED:

--- a/src/allencell_ml_segmenter/widgets/training_widget.py
+++ b/src/allencell_ml_segmenter/widgets/training_widget.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import (
     QSizePolicy,
 )
 
+
 class TrainingWidget(QWidget):
     """
     A sample widget for training a models.


### PR DESCRIPTION
**Summary**

Refactors our pub / sub design so that subscribers can:
- Register a handler for a single event type.
- Unsubscribe a handler (important option for memory management, as app scales).

Also, I made some changes to removed some brittle tests that I encountered.    I'll post some testing guidelines to help us.
 
Also, I cleaned up some lint errors that I noticed.  Our CI should have blocked a merge on those - something I'll look into.

**How to review**
-  Start with `Publisher`.