### PR TITLE
remove flake8 and use black for lint

### DIFF
--- a/.github/workflows/test_lint.yaml
+++ b/.github/workflows/test_lint.yaml
@@ -38,12 +38,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[test_lint]
-      - name: Lint with flake8
+      - name: Lint with Black
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          black --check --verbose .
       - name: Test with pytest
         run: |
           pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ test_lint =
     pytest-qt
     qtpy
     pyqt5
-    flake8
     black
 
 # setup requirements


### PR DESCRIPTION
I dont know why we used flake8 to lint on CI in the first place when we used black locally. Swapped out flake8 for black.

The check happens before pytests are run