### PR TITLE
Enable python 3.11

### DIFF
--- a/.github/workflows/test_lint.yaml
+++ b/.github/workflows/test_lint.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering :: Image Processing
 project_urls =
     Bug Tracker = https://github.com/AllenCell/allencell-ml-segmenter/issues
@@ -32,7 +33,7 @@ project_urls =
 [options.extras_require]
 # project requirements
 project =
-    napari>=0.4.17
+    napari>=0.4.18
     npe2>=0.6.2
     numpy
 


### PR DESCRIPTION
Napari 0.4.18 support python 3.11- enabling it so users can use 3.11 for our plugin.