### PR TITLE
Fix progress bar off by one

### DIFF
--- a/src/allencell_ml_segmenter/_tests/curation/test_curation_main.py
+++ b/src/allencell_ml_segmenter/_tests/curation/test_curation_main.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 @pytest.fixture
 def curation_main_view(qtbot: QtBot) -> CurationMainView:
-    # TODO: refactor, dont mutate fixture in tests below
+    # TODO #161: refactor, dont mutate fixture in tests below
     curation_model: CurationModel = CurationModel()
     experiments_model: FakeExperimentsModel = FakeExperimentsModel()
     curation_service: Mock = Mock(spec=CurationService)
@@ -71,7 +71,7 @@ def test_increment_progress_bar(curation_main_view: CurationMainView) -> None:
     curation_main_view._curation_model.set_raw_images([Path(), Path(), Path()])
     initial_value: int = curation_main_view.progress_bar.value()
     # Act
-    # TODO: refactor, should be testing against public api
+    # TODO #161: refactor, should be testing against public api
     curation_main_view._increment_progress_bar()
     # Assert
     assert curation_main_view.progress_bar.value() == initial_value + 1
@@ -87,7 +87,7 @@ def test_stop_increment_progress_bar_when_curation_finished(
     initial_value: int = curation_main_view.progress_bar.value()
 
     # Act
-    # TODO: refactor, should be testing against public api
+    # TODO #161: refactor, should be testing against public api
     curation_main_view._increment_progress_bar()
     # Assert
     assert curation_main_view.progress_bar.value() == initial_value

--- a/src/allencell_ml_segmenter/curation/main_view.py
+++ b/src/allencell_ml_segmenter/curation/main_view.py
@@ -290,7 +290,7 @@ class CurationMainView(View):
             self._curation_model.get_raw_images()
         ):
             # update progress bar
-            # TODO: refactor, store state of progress bar in model.
+            # TODO #161: refactor, store state of progress bar in model.
             self.progress_bar.setValue(self.progress_bar.value() + 1)
             # set progress bar hint
             self.progress_bar_image_count.setText(


### PR DESCRIPTION
Currently the progress bar is off by one. We start at 0 and finish at max_image_count - 1. We want the progress bar to start at 1 and finish at max_image_count. 

Change Made:

- progress bar initalizes at 1 to fix off by one error