### PR TITLE
Bugfix/training crash when viewer refreshes

### DIFF
--- a/src/allencell_ml_segmenter/prediction/file_input_widget.py
+++ b/src/allencell_ml_segmenter/prediction/file_input_widget.py
@@ -215,7 +215,9 @@ class PredictionFileInput(QWidget):
                 self._image_list.add_item(layer.name)
                 if not max_channels:
                     # This is slow, but there's no way around it
-                    max_channels = extract_num_channels_from_image(path_of_layer_image)
+                    max_channels = extract_num_channels_from_image(
+                        path_of_layer_image
+                    )
         if max_channels:
             self._model.set_max_channels(max_channels)
 


### PR DESCRIPTION
Training runs crash at the end when images are loaded into napari. This causes `PredictionView`'s `FileInputWidget` to refresh its layer list, and since that image has no channels it crashes the plugin. 

This change makes it so that we ignore images generated by Training when the layer list is refreshed. Working on a follow up fix which will make it so that this layer list only refreshes when we are focused on the Prediction tab.