### PR TITLE
Complete release pipeline

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -32,25 +32,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install build bumpver
 
-      # change branch to main for final version
       - name: Bump version
         run: |
-          git checkout feature/release_pipeline_2
-          git config --global user.name 'Publish to PyPI'
-          git config --global user.email 'githubactions@users.noreply.github.com'
+          git checkout main
+          git config --global user.name 'aicsgithub'
+          git config --global user.email 'aicsgithub@alleninstitute.org'
           python publish_bumpver_handler.py ${{ inputs.semver_component }}
 
       - name: Build Package
         run: |
           python -m build
 
-      - name: Publish to Test PyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
       
       - name: Push changes
         run: |
-          git push origin feature/release_pipeline_2
+          git push origin main
           git push origin --tags
       

--- a/README.md
+++ b/README.md
@@ -56,9 +56,16 @@ More useful dev tasks:
 
 Release a new version and publishing to Pypi is based on a Github Actions workflow. The steps are:
 
-- Increment the current version using `bumpversion`. This can be done directly, or using the convenience `make` tasks (eg. `make bumpversion-patch`)
-- Assuming that `main` is up to date with the changes that you intend to release, make a pr from `main` into `release`. Upon getting required approvals and merging, the new version will be published to Pypi and released on Github.
-  - Branch protections apply - currently, merging into `release` is restricted to project maintainers.
+- From repository homepage, go to `actions > Bump version and publish to PyPI`
+- Enter which semantic version component you want to bump for this release
+- Run the workflow
+
+A GitHub runner will then bump the version, build and release to PyPI, and push the version changes back to main.
+
+**Note**: There are restrictions on which component you can bump depending on the current version.
+If the current version has a dev component (e.g. `1.0.1.dev0`), you must bump the dev component or the patch component
+(bumping patch will finalize that patch without any dev version `1.0.1.dev0` -> `1.0.1`). Attempting to bump
+major or minor versions will cause the workflow to fail
 
 ## Installation
 

--- a/publish_bumpver_handler.py
+++ b/publish_bumpver_handler.py
@@ -1,5 +1,6 @@
 # this file is intended to be called by a github workflow (.github/workflows/publish_to_pypi.yaml)
-# it encapsulates logic that is too complex to be expressed in workflow syntax
+# it makes decisions based on the current version and the component specified for bumping,
+# which the workflow cannot do
 import subprocess
 import sys
 from typing import Set, List

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 # https://peps.python.org/pep-0621/
 [project]
 name = "allencell-ml-segmenter"
-version = "0.0.10"
+version = "0.0.9"
 description = "A plugin to leverage ML segmentation in napari"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -97,7 +97,7 @@ where = ["src"]
 
 # https://pypi.org/project/bumpver
 [tool.bumpver]
-current_version = "0.0.10"
+current_version = "0.0.9"
 version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 tag_message = "v{new_version}"

--- a/src/allencell_ml_segmenter/__init__.py
+++ b/src/allencell_ml_segmenter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.10"
+__version__ = "0.0.9"
 
 from allencell_ml_segmenter.napari.napari_reader import napari_get_reader
 from allencell_ml_segmenter.napari.sample_data import make_sample_data


### PR DESCRIPTION
### Context
This PR concludes the initial work on the new release pipeline. You can see the workflow [here](https://github.com/AllenCell/allencell-ml-segmenter/actions/workflows/publish_to_pypi.yaml), but don't actually run it yet (it shouldn't be able to publish to PyPI yet but just being careful).

You can choose `major, minor, patch, dev` as a version component to update, then the workflow will bump the version, build and upload to PyPI, and push the version changes back to main. See the updated `README.md` for a more complete description of the process.

### Changes
- `publish_bumpver_handler.py`: python script for handling component bump requests based on the current version
- `publish_to_pypi.yaml`: updated config information

### Testing
I tested the full pipeline with TestPyPI ([logs here](https://github.com/AllenCell/allencell-ml-segmenter/actions/runs/8071595930/))

### Next Steps
Once this PR is merged, we need to make a request to add our repo as a trusted publisher via [aicspypi](https://pypi.org/user/aicspypi/). We won't be able to actually upload to PyPI until this happens.

### Further Issues
- I was unable to edit the workflow file from within a github runner, so I couldn't have the current version show up in the workflow description. Made [an issue for that](https://github.com/AllenCell/allencell-ml-segmenter/issues/190) on this repo
- The default behavior for a manually-triggered workflow is that anyone with write permissions to the repo can run it. This is fine for now, but we may want to consider other approaches once we make the repo public.