### PR TITLE
add artifactory release workflow

### DIFF
--- a/.github/workflows/publish_to_artifactory.yaml
+++ b/.github/workflows/publish_to_artifactory.yaml
@@ -10,6 +10,11 @@ on:
         description: "Semantic versioning component to bump (must be one of {major, minor, patch, dev})"
         required: true
 
+# needed to grab org secrets for artifactory publish
+env:
+  ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
 jobs:
   publish:
     name: Bump and publish


### PR DESCRIPTION
Adding a workflow for Artifactory releases. We can remove this once we have it up on PyPi, but let's keep while we're publishing internally.
With this we should be able to trigger releases from github-actions onto artifactory by providing a version component to bump

Change
- Added `publish_to_artifactory` workflow. This is mostly the same thing as @saeliddp 's work done on `publish_to_pypi`, but with the Publish to PyPi step replaced with whats needed to get things on artifactory.


Todo

- Need to get the `ARTIFACTORY_TWINE_USER` + `ARTIFACTORY_TWINE_USER_PASSWORD` from infra


