### PR TITLE
artifactory pub workflow runs on self hosted

### DIFF
--- a/.github/workflows/publish_to_artifactory.yaml
+++ b/.github/workflows/publish_to_artifactory.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   publish:
     name: Bump and publish
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, build]
     environment: release
     permissions:
       id-token: write


### PR DESCRIPTION
1 liner to make `.github/workflows/publish_to_artifactory.yaml` run on our self hosted runner.