### PR TITLE
Update curation main view tests

### DIFF
--- a/src/allencell_ml_segmenter/_tests/curation/test_curation_service.py
+++ b/src/allencell_ml_segmenter/_tests/curation/test_curation_service.py
@@ -17,6 +17,7 @@ from allencell_ml_segmenter.curation.curation_service import (
 )
 from allencell_ml_segmenter.curation.curation_image_loader import (
     FakeCurationImageLoader,
+    FakeCurationImageLoaderFactory,
 )
 from allencell_ml_segmenter.core.image_data_extractor import ImageData
 from allencell_ml_segmenter.main.experiments_model import ExperimentsModel
@@ -30,7 +31,7 @@ def test_build_raw_images_list() -> None:
     cur_tests_path = Path(__file__).parent / "curation_tests"
     curation_model.set_raw_directory(cur_tests_path)
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     # Act
     raw_images: List[Path] = curation_service.build_raw_images_list()
@@ -50,7 +51,7 @@ def test_build_raw_images_list_invalid_path() -> None:
     # Arrange
     curation_model: CurationModel = CurationModel()
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     # There is no raw direcotry set in the model- getter returns None
     # Act/ assert
@@ -64,7 +65,7 @@ def test_build_seg1_images_list() -> None:
     cur_tests_path = Path(__file__).parent / "curation_tests"
     curation_model.set_seg1_directory(cur_tests_path)
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
 
     # Act
@@ -88,7 +89,7 @@ def test_build_seg1_images_list_invalid_path() -> None:
     # Arrange
     curation_model: CurationModel = CurationModel()
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     # There is no raw direcotry set in the model- getter returns None
     # Act/ assert
@@ -102,7 +103,7 @@ def test_build_seg2_images_list() -> None:
     cur_tests_path = Path(__file__).parent / "curation_tests"
     curation_model.set_seg2_directory(cur_tests_path)
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
 
     # Act
@@ -126,7 +127,7 @@ def test_build_seg2_images_list_invalid_path() -> None:
     # Arrange
     curation_model: CurationModel = CurationModel()
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     # There is no raw direcotry set in the model- getter returns None
     # Act/ assert
@@ -138,7 +139,7 @@ def test_remove_all_images_from_viewer_layers() -> None:
     # Arrange
     fake_viewer: FakeViewer = FakeViewer()
     curation_service_fake_viewer: CurationService = CurationService(
-        Mock(spec=CurationModel), fake_viewer
+        Mock(spec=CurationModel), fake_viewer, FakeCurationImageLoaderFactory()
     )
 
     # Act
@@ -152,7 +153,7 @@ def test_add_image_to_viewer() -> None:
     # Arrange
     fake_viewer: FakeViewer = FakeViewer()
     curation_service_fake_viewer: CurationService = CurationService(
-        Mock(spec=CurationModel), fake_viewer
+        Mock(spec=CurationModel), fake_viewer, FakeCurationImageLoaderFactory()
     )
 
     # Act
@@ -203,7 +204,7 @@ def test_enable_shape_selection_viewer_merging() -> None:
         lambda e: fake_subscriber.handle(e),
     )
     curation_service_fake_viewer: CurationService = CurationService(
-        curation_model, fake_viewer
+        curation_model, fake_viewer, FakeCurationImageLoaderFactory()
     )
 
     # Act
@@ -226,7 +227,7 @@ def test_select_directory_raw(start_mock: Mock) -> None:
     # Arrange
     model: CurationModel = CurationModel()
     curation_service: CurationService = CurationService(
-        curation_model=model, viewer=Mock(spec=Viewer)
+        model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     img_folder: Path = (
         Path(allencell_ml_segmenter.__file__).parent
@@ -262,7 +263,7 @@ def test_select_directory_seg1(start_mock: Mock) -> None:
     # Arrange
     model: CurationModel = CurationModel()
     curation_service: CurationService = CurationService(
-        curation_model=model, viewer=Mock(spec=Viewer)
+        model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     img_folder: Path = (
         Path(allencell_ml_segmenter.__file__).parent
@@ -299,7 +300,7 @@ def test_select_directory_seg2(start_mock: Mock) -> None:
     model = CurationModel()
 
     curation_service = CurationService(
-        curation_model=model, viewer=Mock(spec=Viewer)
+        model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     img_folder: Path = (
         Path(allencell_ml_segmenter.__file__).parent
@@ -331,7 +332,9 @@ def test_select_directory_seg2(start_mock: Mock) -> None:
 def test_write_curation_record() -> None:
     # Arrange
     curation_service: CurationService = CurationService(
-        Mock(spec=CurationModel), Mock(spec=Viewer)
+        Mock(spec=CurationModel),
+        Mock(spec=Viewer),
+        FakeCurationImageLoaderFactory(),
     )
     curation_record: List[CurationRecord] = [
         CurationRecord(
@@ -428,7 +431,7 @@ def test_update_curation_record(
         )
     )
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     curation_model.get_current_excluding_mask_path_and_reset_mask = Mock(
         return_value="excluding_mask_path"
@@ -461,7 +464,7 @@ def test_finished_shape_selection_excluding() -> None:
     # Arrange
     curation_model: CurationModel = CurationModel()
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     curation_model.get_excluding_mask_shape_layers = Mock()
     shapes: Shapes = Shapes()
@@ -478,7 +481,7 @@ def test_finished_shape_selection_merging() -> None:
     # Arrange
     curation_model: CurationModel = CurationModel()
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     curation_model.get_merging_mask_shape_layers = Mock()
     shapes: Shapes = Shapes()
@@ -502,7 +505,7 @@ def test_clear_merging_mask_layers_all() -> None:
     ]
     curation_model.set_merging_mask_shape_layers(shapes_layers)
     test_service_with_viewer: CurationService = CurationService(
-        curation_model, fake_viewer
+        curation_model, fake_viewer, FakeCurationImageLoaderFactory()
     )
     assert len(curation_model.get_merging_mask_shape_layers()) > 0
 
@@ -528,7 +531,7 @@ def test_clear_excluding_mask_layers_all() -> None:
 
     fake_viewer: FakeViewer = FakeViewer()
     curation_service: CurationService = CurationService(
-        curation_model, fake_viewer
+        curation_model, fake_viewer, FakeCurationImageLoaderFactory()
     )
     assert len(curation_model.get_excluding_mask_shape_layers()) > 0
 
@@ -554,7 +557,7 @@ def test_next_image_no_seg2() -> None:
     )
     viewer: FakeViewer = FakeViewer()
     test_service_with_model: CurationService = CurationService(
-        curation_model=model, viewer=viewer
+        model, viewer, FakeCurationImageLoaderFactory()
     )
     raw_path: Mock = Mock(spec=Path)
     model.get_save_masks_path = Mock(return_value=Path("fake_path_save_mask"))
@@ -586,7 +589,7 @@ def test_next_image_with_seg2() -> None:
     )
     viewer: FakeViewer = FakeViewer()
     test_service_with_model: CurationService = CurationService(
-        curation_model=model, viewer=viewer
+        model, viewer, FakeCurationImageLoaderFactory()
     )
     test_service_with_model.update_curation_record = Mock()
 
@@ -615,7 +618,7 @@ def test_next_image_finished() -> None:
     curation_model.get_image_loader().next()
     curation_model.get_image_loader().next()
     curation_service: CurationService = CurationService(
-        curation_model, Mock(spec=Viewer)
+        curation_model, Mock(spec=Viewer), FakeCurationImageLoaderFactory()
     )
     curation_service.update_curation_record = Mock()
     curation_service.write_curation_record = Mock()

--- a/src/allencell_ml_segmenter/curation/curation_data_class.py
+++ b/src/allencell_ml_segmenter/curation/curation_data_class.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 
 @dataclass
 class CurationRecord:
     raw_file: Path
     seg1: Path
-    seg2: Path
+    seg2: Optional[Path]
     excluding_mask: str
     merging_mask: str
     base_image_index: str

--- a/src/allencell_ml_segmenter/curation/curation_image_loader/__init__.py
+++ b/src/allencell_ml_segmenter/curation/curation_image_loader/__init__.py
@@ -1,3 +1,6 @@
 from .i_curation_image_loader import ICurationImageLoader
 from .curation_image_loader import CurationImageLoader
 from .fake_curation_image_loader import FakeCurationImageLoader
+from .i_curation_image_loader_factory import ICurationImageLoaderFactory
+from .curation_image_loader_factory import CurationImageLoaderFactory
+from .fake_curation_image_loader_factory import FakeCurationImageLoaderFactory

--- a/src/allencell_ml_segmenter/curation/curation_image_loader/curation_image_loader_factory.py
+++ b/src/allencell_ml_segmenter/curation/curation_image_loader/curation_image_loader_factory.py
@@ -1,0 +1,15 @@
+from .i_curation_image_loader import ICurationImageLoader
+from .i_curation_image_loader_factory import ICurationImageLoaderFactory
+from .curation_image_loader import CurationImageLoader
+from typing import Optional, List
+from pathlib import Path
+
+
+class CurationImageLoaderFactory(ICurationImageLoaderFactory):
+    def create(
+        self,
+        raw_images: List[Path],
+        seg1_images: List[Path],
+        seg2_images: Optional[List[Path]] = None,
+    ) -> ICurationImageLoader:
+        return CurationImageLoader(raw_images, seg1_images, seg2_images)

--- a/src/allencell_ml_segmenter/curation/curation_image_loader/fake_curation_image_loader_factory.py
+++ b/src/allencell_ml_segmenter/curation/curation_image_loader/fake_curation_image_loader_factory.py
@@ -1,0 +1,15 @@
+from .i_curation_image_loader import ICurationImageLoader
+from .i_curation_image_loader_factory import ICurationImageLoaderFactory
+from .fake_curation_image_loader import FakeCurationImageLoader
+from typing import Optional, List
+from pathlib import Path
+
+
+class FakeCurationImageLoaderFactory(ICurationImageLoaderFactory):
+    def create(
+        self,
+        raw_images: List[Path],
+        seg1_images: List[Path],
+        seg2_images: Optional[List[Path]] = None,
+    ) -> ICurationImageLoader:
+        return FakeCurationImageLoader(raw_images, seg1_images, seg2_images)

--- a/src/allencell_ml_segmenter/curation/curation_image_loader/i_curation_image_loader.py
+++ b/src/allencell_ml_segmenter/curation/curation_image_loader/i_curation_image_loader.py
@@ -3,11 +3,9 @@ from typing import List, Optional
 from pathlib import Path
 from allencell_ml_segmenter.core.q_runnable_manager import (
     IQRunnableManager,
-    GlobalQRunnableManager,
 )
 from allencell_ml_segmenter.core.image_data_extractor import (
     IImageDataExtractor,
-    AICSImageDataExtractor,
     ImageData,
 )
 

--- a/src/allencell_ml_segmenter/curation/curation_image_loader/i_curation_image_loader_factory.py
+++ b/src/allencell_ml_segmenter/curation/curation_image_loader/i_curation_image_loader_factory.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+from .i_curation_image_loader import ICurationImageLoader
+
+
+class ICurationImageLoaderFactory(ABC):
+    @abstractmethod
+    def create(self) -> ICurationImageLoader:
+        pass

--- a/src/allencell_ml_segmenter/curation/curation_widget.py
+++ b/src/allencell_ml_segmenter/curation/curation_widget.py
@@ -13,6 +13,9 @@ from allencell_ml_segmenter.curation.curation_model import CurationModel
 from allencell_ml_segmenter.curation.input_view import CurationInputView
 from allencell_ml_segmenter.curation.main_view import CurationMainView
 from allencell_ml_segmenter.curation.curation_service import CurationService
+from allencell_ml_segmenter.curation.curation_image_loader import (
+    CurationImageLoaderFactory,
+)
 
 import napari
 from napari.utils.notifications import show_info
@@ -46,7 +49,7 @@ class CurationWidget(QStackedWidget, Subscriber, metaclass=CurationUiMeta):
             experiments_model=experiments_model
         )
         self.curation_service: CurationService = CurationService(
-            curation_model=self.curation_model, viewer=self.viewer
+            self.curation_model, self.viewer, CurationImageLoaderFactory()
         )
 
         # basic styling


### PR DESCRIPTION
## Context
[Issue 232](https://github.com/AllenCell/allencell-ml-segmenter/issues/232)

Because of the discussion that led to issue 232, I changed the `MainView` tests to primarily make assertions based on the state of the UI attributes of `MainView`. This testing strategy makes sense if we think of the UI elements defined by `MainView` to be the 'API' of `MainView`, and the UI changes as a result of a client/user action on the UI as the 'contract'.

## Notes
- the tests I've included are just for initialization and `next` because it seems like we might have significant curation UI changes moving forward, and I don't want to complicate that development (but, these tests should be updated and expanded upon once the UI is in a stable state)
- with the current code base, some mocks are necessary in order to avoid side effects that impact with the file system and would slow our tests down significantly
