### PR TITLE
274 prediction UI remove prepost processing section

### DIFF
--- a/src/allencell_ml_segmenter/prediction/view.py
+++ b/src/allencell_ml_segmenter/prediction/view.py
@@ -66,10 +66,11 @@ class PredictionView(View):
         )
         self._file_input_widget.setObjectName("fileInput")
 
-        self._model_input_widget: ModelInputWidget = ModelInputWidget(
-            self._prediction_model
-        )
-        self._model_input_widget.setObjectName("modelInput")
+        # Disabled for V1 chrishu 3/30/24 https://github.com/AllenCell/allencell-ml-segmenter/issues/274
+        # self._model_input_widget: ModelInputWidget = ModelInputWidget(
+        #     self._prediction_model
+        # )
+        # self._model_input_widget.setObjectName("modelInput")
 
         # Dummy divs allow for easy alignment
         top_container: QVBoxLayout = QVBoxLayout()
@@ -81,7 +82,9 @@ class PredictionView(View):
         top_dummy.setLayout(top_container)
         self.layout().addWidget(top_dummy)
 
-        bottom_container.addWidget(self._model_input_widget)
+        # Disabled for V1 chrishu 3/30/24 https://github.com/AllenCell/allencell-ml-segmenter/issues/274
+        # bottom_container.addWidget(self._model_input_widget)
+
         bottom_dummy.setLayout(bottom_container)
         self.layout().addWidget(bottom_dummy)
 

--- a/src/allencell_ml_segmenter/training/model_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/model_selection_widget.py
@@ -56,7 +56,9 @@ class ModelSelectionWidget(QWidget):
 
         self._experiment_name_input: QLineEdit = QLineEdit()
         self._experiment_name_input.setPlaceholderText("Name your model")
-        self._experiment_name_input.textChanged.connect(self._experiment_name_input_handler)
+        self._experiment_name_input.textChanged.connect(
+            self._experiment_name_input_handler
+        )
 
         label_new_model: LabelWithHint = LabelWithHint("Start a new model")
         top_grid_layout.addWidget(label_new_model, 0, 1)


### PR DESCRIPTION
Removes the pre/post processing section from the prediction UI:
<img width="546" alt="image" src="https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/df84bcb5-3159-43aa-86ae-fdedb86951ec">
