### PR TITLE
bugfix/num_workers_value_fix

### DIFF
--- a/src/allencell_ml_segmenter/utils/cuda_util.py
+++ b/src/allencell_ml_segmenter/utils/cuda_util.py
@@ -2,6 +2,8 @@ import multiprocessing
 import torch
 import platform
 
+from allencell_ml_segmenter.training.training_model import Hardware
+
 
 class CUDAUtils:
 
@@ -14,7 +16,7 @@ class CUDAUtils:
         return torch.cuda.is_available()
 
     @staticmethod
-    def get_num_workers(use_gpu: bool = False) -> int:
+    def get_num_workers(hardware_used: Hardware) -> int:
         """
         Get the number of available cpu cores on this machine
         """
@@ -22,7 +24,7 @@ class CUDAUtils:
         # On MACOS we cannot set num_workers no matter what.
         # On CPU, increasing num_workers will offer no performance increase
         #   as dataloading is not the bottleneck
-        if platform.system() == "Darwin" or not use_gpu:
+        if platform.system() == "Darwin" or hardware_used == Hardware.CPU:
             return 0
         # For Windows/Linux:
         # We set num_workers to 1 for GPU runs

--- a/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
+++ b/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
@@ -36,9 +36,14 @@ class CytoDLOverridesManager:
         overrides_dict: Dict[str, Union[str, int, float, bool, Dict]] = dict()
 
         # Hardware override (required)
+        hardware_used = self._training_model.get_hardware_type()
         overrides_dict["trainer.accelerator"] = "cpu"
-        if self._training_model.get_hardware_type() == Hardware.GPU:
+        if hardware_used == Hardware.GPU:
             overrides_dict["trainer.accelerator"] = "gpu"
+
+        overrides_dict["data.num_workers"] = CUDAUtils.get_num_workers(
+            hardware_used
+        )
 
         # Spatial Dims (required)
         overrides_dict["spatial_dims"] = (
@@ -83,10 +88,5 @@ class CytoDLOverridesManager:
         overrides_dict["model._aux.filters"] = (
             self._training_model.get_model_size().value
         )
-
-        # num_workers based on cpu cores available on machine
-        # it is recommended to leave one or two logical cores free to work on other
-        # system tasks will prevent starving the system of resources completely
-        overrides_dict["data.num_workers"] = CUDAUtils.get_num_workers()
 
         return overrides_dict


### PR DESCRIPTION
Some context:
The dataloader will crash on apple silicon computers if we set num_workers > 0 due to this known pytorch issue: https://github.com/pytorch/pytorch/issues/46648. 

While testing the fix for this on my windows machine w/ 16cores + 16gb memory I found some weird behavior that I had to investigate further (Using medium model size/medium patch size):

- `num_workers=15` will use >16GB memory for most datasets.
-  `num_workers=8` will use >16GB memory for some datasets with larger images
-  `num_workers=4` takes 10 min 27 sec to run the first epoch, and 32 seconds for every subsequent epoch
-  `num_workers=1` takes 10 min 45 sec to run the first epoch, and 36 seconds for every subsequent epoch

This is what benji and I decided was the best way to set `num_workers`:
- All mac runs we are setting `num_workers=0 ` due to the pytorch issue.
- Since cpu runs won't see a performance increase from increasing `num_workers`, all cpu runs also use `num_workers=0`.
- GPU runs dont see a huge speed increase from increasing `num_workers`, and `workers>=4` can cause close to 16gb memory usage, at least for some images from our variance datasets. Since we dont know how much memory our users will have, we use a conservative `num_workers=1`. 


Changes made:

- `utils/cuda_util.py`: Changed `get_num_cpu_cores()` to `get_num_workers()`. Behavior for get_num_workers() is described above.
- `utils/cyto_overrides_manager.py]`: using the new get_num_workers()` function