### PR TITLE
change way we get patch size if 2-d selected

### DIFF
--- a/src/allencell_ml_segmenter/_tests/utils/test_cyto_overrides_manager.py
+++ b/src/allencell_ml_segmenter/_tests/utils/test_cyto_overrides_manager.py
@@ -9,6 +9,7 @@ from allencell_ml_segmenter.main.experiments_model import ExperimentsModel
 from allencell_ml_segmenter.main.main_model import MainModel
 from allencell_ml_segmenter.training.training_model import (
     TrainingModel,
+    PatchSize,
 )
 from allencell_ml_segmenter.utils.cyto_overrides_manager import (
     CytoDLOverridesManager,
@@ -37,7 +38,7 @@ def training_model(experiments_model: ExperimentsModel) -> TrainingModel:
     model: TrainingModel = TrainingModel(MainModel(), experiments_model)
     model.set_experiment_type("segmentation")
     model.set_hardware_type("cpu")
-    model.set_spatial_dims(2)
+    model.set_spatial_dims(3)
     model.set_images_directory("/path/to/images")
     model.set_channel_index(9)
     model.set_use_max_time(True)
@@ -97,6 +98,38 @@ def test_get_training_overrides(
             experiments_model.get_experiment_name(),
             experiments_model.get_checkpoint(),
         )
+    )
+
+
+def test_get_training_overrides_2d_spatial_dims(experiments_model) -> None:
+    # Arrange
+    model: TrainingModel = TrainingModel(MainModel(), experiments_model)
+    model.set_experiment_type("segmentation")
+    model.set_hardware_type("cpu")
+    model.set_images_directory("/path/to/images")
+    model.set_channel_index(9)
+    model.set_use_max_time(True)
+    model.set_max_time(9992)
+    model.set_config_dir("/path/to/configs")
+    model.set_num_epochs(100)
+    model.set_model_size("medium")
+
+    model.set_spatial_dims(2)
+    model.set_patch_size("small")
+    cyto_overrides_manager: CytoDLOverridesManager = CytoDLOverridesManager(
+        experiments_model, model
+    )
+
+    # Act
+    training_overrides: Dict[str, Union[str, int, float, bool, Dict]] = (
+        cyto_overrides_manager.get_training_overrides()
+    )
+
+    # Assert
+    assert len(training_overrides["data._aux.patch_shape"]) == 2
+    assert (
+        training_overrides["data._aux.patch_shape"]
+        == PatchSize.SMALL.value[1:]
     )
 
 

--- a/src/allencell_ml_segmenter/training/training_model.py
+++ b/src/allencell_ml_segmenter/training/training_model.py
@@ -32,7 +32,7 @@ class Hardware(Enum):
 class PatchSize(Enum):
     """
     Patch size for training, and their respective patch shapes.
-    TODO: get from benji
+    The 0th dimension is Z, which is not needed for 2d.
     """
 
     SMALL = [1, 3, 3]


### PR DESCRIPTION
For 2d training- we are getting an error because all of our patch shapes are 3d.
PatchSize's have a `ZYX` dimension order, so we just need to ignore the first index, keeping the `YX` dimensions for 2d images.

Tested on windows

Changes Made:

- [utils/cyto_overrides_manager.py](https://github.com/AllenCell/allencell-ml-segmenter/compare/feature/2d_patchsize?expand=1#diff-c950cd65574721ca00190bb515c5b6373a23c1fd4872481eaf371d4b92ef3005): spatial_dims override is set to a 2d `PatchSize` if the user has 2d selected, otherwise we use the default `PatchSize`
- [test_cyto_overrides_manager.py](https://github.com/AllenCell/allencell-ml-segmenter/compare/feature/2d_patchsize?expand=1#diff-4868afc2b52cada72d42b20d06e7d8f3a5ef09beae2530ec168a5921b9416b9c): added a test to see if we are setting the correct 2d `PatchSize` override if the user has 2d selected
- [training/training_model.py](https://github.com/AllenCell/allencell-ml-segmenter/compare/feature/2d_patchsize?expand=1#diff-ef2e904c994f8ad6f5d272103b75ba1dff359adff4203d58ed1585d0195ac3be): comment for clarity
