### PR TITLE
plugin title, help menu

### DIFF
--- a/src/allencell_ml_segmenter/training/model_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/model_selection_widget.py
@@ -56,8 +56,12 @@ class ModelSelectionWidget(QWidget):
         help.setPlaceholderText("Help")
 
         plugin_title_widget_layout: QHBoxLayout = QHBoxLayout()
-        plugin_title_widget_layout.addWidget(QLabel("Allen Cell & Structure Segmentation"))
-        plugin_title_widget_layout.addWidget(help, alignment=Qt.AlignmentFlag.AlignRight)
+        plugin_title_widget_layout.addWidget(
+            QLabel("Allen Cell & Structure Segmentation")
+        )
+        plugin_title_widget_layout.addWidget(
+            help, alignment=Qt.AlignmentFlag.AlignRight
+        )
 
         layout.setContentsMargins(20, 20, 20, 20)
         layout.addLayout(plugin_title_widget_layout)


### PR DESCRIPTION
**Objective**: Adding the plugin title and help menu (stub) designed by @thao-do:
Demo:
<img width="627" alt="image" src="https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/d74724cf-66d5-49a3-9f00-a03bd1094921">
Mockup:
<img width="399" alt="image" src="https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/71e0e1fa-6b83-4278-adbb-5ff516c0baf4">


