### PR TITLE
init tabs disabled

### DIFF
--- a/src/allencell_ml_segmenter/main/main_widget.py
+++ b/src/allencell_ml_segmenter/main/main_widget.py
@@ -94,6 +94,7 @@ class MainWidget(AicsWidget):
 
         # keep track of views
         self._view_container: QTabWidget = QTabWidget()
+        self._view_container.setDisabled(True)
         self._view_to_index: Dict[View, int] = dict()
 
         self._experiments_model.subscribe(


### PR DESCRIPTION
**Objective** At some point a bug crept in where the tabs initialized enabled.  They need to be disabled until an experiment selection is applied.

**Demo**
Before applying selection:
![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/4799b703-a5ac-4074-a3fc-abba4ff4cdea)

![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/b513d6f7-8167-44aa-82b1-6dd317a132ba)

After:
![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/94307e4c-2bd2-413f-ad1a-b259bdd4e162)
