### PR TITLE
254 add a dropdown menu for help to all plugin screen

### DIFF
--- a/src/allencell_ml_segmenter/training/model_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/model_selection_widget.py
@@ -60,8 +60,17 @@ class ModelSelectionWidget(QWidget):
         self.help_combo_box: QComboBox = QComboBox()
         self.help_combo_box.setFixedWidth(100)
         self.help_combo_box.setPlaceholderText("Help")
-        self.help_combo_box.addItems([ModelSelectionWidget.TUTORIAL_TEXT, ModelSelectionWidget.GITHUB_TEXT, ModelSelectionWidget.FORUM_TEXT, ModelSelectionWidget.WEBSITE_TEXT])
-        self.help_combo_box.currentTextChanged.connect(self._help_combo_handler)
+        self.help_combo_box.addItems(
+            [
+                ModelSelectionWidget.TUTORIAL_TEXT,
+                ModelSelectionWidget.GITHUB_TEXT,
+                ModelSelectionWidget.FORUM_TEXT,
+                ModelSelectionWidget.WEBSITE_TEXT,
+            ]
+        )
+        self.help_combo_box.currentTextChanged.connect(
+            self._help_combo_handler
+        )
 
         plugin_title_widget_layout: QHBoxLayout = QHBoxLayout()
         plugin_title_widget_layout.addWidget(


### PR DESCRIPTION
**Objective**: Implement the spec'd help menu and its functionality.

**Demo**:
![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/2b4567b8-0e87-441c-a365-b3fc01f7ed51)
**Mockup**:
<img width="981" alt="image" src="https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/580c3a76-7b57-45f2-a448-fd2657370feb">

**Testing**: Manual (the spec'd web pages launch in the user's bowser)

I know that the text color is blue in the mockup - this has proven non trivial to achieve.  I say close enough (for now). 