### PR TITLE
Fix GPU not being used

### DIFF
--- a/src/allencell_ml_segmenter/_tests/services/test_training_service.py
+++ b/src/allencell_ml_segmenter/_tests/services/test_training_service.py
@@ -37,7 +37,6 @@ def experiments_model() -> ExperimentsModel:
 def training_model(experiments_model: ExperimentsModel) -> TrainingModel:
     model: TrainingModel = TrainingModel(MainModel(), experiments_model)
     model.set_experiment_type("segmentation")
-    model.set_hardware_type("cpu")
     model.set_spatial_dims(2)
     model.set_images_directory("/path/to/images")
     model.set_channel_index(9)

--- a/src/allencell_ml_segmenter/_tests/training/test_model.py
+++ b/src/allencell_ml_segmenter/_tests/training/test_model.py
@@ -8,7 +8,6 @@ from allencell_ml_segmenter.main.main_model import MainModel
 from allencell_ml_segmenter.training.training_model import (
     TrainingModel,
     TrainingType,
-    Hardware,
 )
 
 
@@ -57,32 +56,6 @@ def test_set_experiment_type_invalid_experiment(
     # ACT
     with pytest.raises(ValueError):
         training_model.set_experiment_type("invalid_experiment")
-
-
-def test_get_hardware_type(training_model: TrainingModel) -> None:
-    """
-    Tests that get_hardware_type returns the correct hardware type.
-    """
-    # ASSERT
-    assert training_model.get_hardware_type() is None
-
-    # ARRANGE
-    hardware: Hardware = Hardware("cpu")
-    training_model._hardware_type = hardware
-
-    # ACT/ASSERT
-    assert training_model.get_hardware_type() == hardware
-
-
-def test_set_hardware_type(training_model: TrainingModel) -> None:
-    """
-    Tests that set_hardware_type sets the correct hardware type.
-    """
-    # ACT
-    training_model.set_hardware_type("gpu")
-
-    # ASSERT
-    assert training_model._hardware_type == Hardware("gpu")
 
 
 def test_get_image_dims(training_model: TrainingModel) -> None:

--- a/src/allencell_ml_segmenter/_tests/utils/test_cyto_overrides_manager.py
+++ b/src/allencell_ml_segmenter/_tests/utils/test_cyto_overrides_manager.py
@@ -36,7 +36,6 @@ def experiments_model() -> ExperimentsModel:
 def training_model(experiments_model: ExperimentsModel) -> TrainingModel:
     model: TrainingModel = TrainingModel(MainModel(), experiments_model)
     model.set_experiment_type("segmentation")
-    model.set_hardware_type("cpu")
     model.set_spatial_dims(3)
     model.set_images_directory("/path/to/images")
     model.set_channel_index(9)
@@ -59,12 +58,6 @@ def test_get_training_overrides(
 
     training_overrides: Dict[str, Union[str, int, float, bool, Dict]] = (
         cyto_overrides_manager.get_training_overrides()
-    )
-
-    # ASSERT
-    assert (
-        training_overrides["trainer.accelerator"]
-        == training_model.get_hardware_type().value
     )
 
     assert (
@@ -104,7 +97,6 @@ def test_get_training_overrides_2d_spatial_dims(experiments_model) -> None:
     # Arrange
     model: TrainingModel = TrainingModel(MainModel(), experiments_model)
     model.set_experiment_type("segmentation")
-    model.set_hardware_type("cpu")
     model.set_images_directory("/path/to/images")
     model.set_channel_index(9)
     model.set_use_max_time(True)

--- a/src/allencell_ml_segmenter/services/training_service.py
+++ b/src/allencell_ml_segmenter/services/training_service.py
@@ -14,9 +14,6 @@ from allencell_ml_segmenter.core.event import Event
 
 from cyto_dl.api.model import CytoDLModel
 from allencell_ml_segmenter.main.experiments_model import ExperimentsModel
-from allencell_ml_segmenter.training.training_model import (
-    Hardware,
-)
 from allencell_ml_segmenter.training.training_model import TrainingModel
 from typing import Dict, Union, Optional, List, Any, Callable
 from napari.utils.notifications import show_warning

--- a/src/allencell_ml_segmenter/training/training_model.py
+++ b/src/allencell_ml_segmenter/training/training_model.py
@@ -20,15 +20,6 @@ class TrainingType(Enum):
     SKOOTS = "skoots"
 
 
-class Hardware(Enum):
-    """
-    Hardware, "cpu" or "gpu"
-    """
-
-    CPU = "cpu"
-    GPU = "gpu"
-
-
 class ModelSize(Enum):
     """
     Model size for training, and their respective filters overrides
@@ -51,7 +42,6 @@ class TrainingModel(Publisher):
         self._main_model = main_model
         self.experiments_model = experiments_model
         self._experiment_type: TrainingType = None
-        self._hardware_type: Hardware = None
         self._images_directory: Path = None
         self._channel_index: Union[int, None] = None
         self._model_path: Union[Path, None] = (
@@ -85,21 +75,6 @@ class TrainingModel(Publisher):
         """
         # convert string to enum
         self._experiment_type = TrainingType(training_type)
-
-    def get_hardware_type(self) -> Hardware:
-        """
-        Gets hardware type
-        """
-        return self._hardware_type
-
-    def set_hardware_type(self, hardware_type: str) -> None:
-        """
-        Sets hardware type
-
-        hardware_type (Path): what hardware to train on, "cpu" or "gpu"
-        """
-        # convert string to enum
-        self._hardware_type = Hardware(hardware_type.lower())
 
     def get_spatial_dims(self) -> int:
         """

--- a/src/allencell_ml_segmenter/utils/cuda_util.py
+++ b/src/allencell_ml_segmenter/utils/cuda_util.py
@@ -2,8 +2,6 @@ import multiprocessing
 import torch
 import platform
 
-from allencell_ml_segmenter.training.training_model import Hardware
-
 
 class CUDAUtils:
 

--- a/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
+++ b/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
@@ -3,7 +3,6 @@ from typing import Dict, Union, Optional, List
 from allencell_ml_segmenter.main.experiments_model import ExperimentsModel
 from allencell_ml_segmenter.training.training_model import (
     TrainingModel,
-    Hardware,
 )
 from allencell_ml_segmenter.utils.cuda_util import CUDAUtils
 


### PR DESCRIPTION
This should solve gpu not being used during training.

Changes made:

- [utils/cyto_overrides_manager.py](https://github.com/AllenCell/allencell-ml-segmenter/compare/bugfix/use_gpu_fix?expand=1#diff-c950cd65574721ca00190bb515c5b6373a23c1fd4872481eaf371d4b92ef3005): Use `CUDAUtils` directly to determine whether or not we should use gpu

- [utils/cuda_util.py](https://github.com/AllenCell/allencell-ml-segmenter/compare/bugfix/use_gpu_fix?expand=1#diff-78ec845f6e0cd4f7b6eba5e36f759a29acfe3fab2e2dccf60440e61ef84ffd64): Use `CUDAUtils` to determine num workers as well

Testing:
working on mac and windows
tests pass