### PR TITLE
asyncio code cleanup

### DIFF
--- a/src/allencell_ml_segmenter/sample/process/service.py
+++ b/src/allencell_ml_segmenter/sample/process/service.py
@@ -30,6 +30,5 @@ class SampleProcessService:
         else:
             self._sample_model.set_process_running(True)
             for file in self._sample_model.get_training_input_files():
-                # await asyncio.sleep(1)
                 self._sample_model.append_training_output_files([file])
             self._sample_model.set_process_running(False)

--- a/src/allencell_ml_segmenter/services/prediction_service.py
+++ b/src/allencell_ml_segmenter/services/prediction_service.py
@@ -1,4 +1,3 @@
-import asyncio
 import csv
 
 from allencell_ml_segmenter.core.subscriber import Subscriber
@@ -65,7 +64,7 @@ class PredictionService(Subscriber):
                 self._experiments_model.get_checkpoint(),
             )
         )
-        asyncio.run(cyto_api.predict(run_async=True))
+        cyto_api.predict()
 
     def _prediction_setup(self, _: Event):
         if self._able_to_continue_prediction():

--- a/src/allencell_ml_segmenter/services/training_service.py
+++ b/src/allencell_ml_segmenter/services/training_service.py
@@ -1,9 +1,5 @@
-import asyncio
 from pathlib import Path
 
-from allencell_ml_segmenter._tests.fakes.fake_channel_extraction import (
-    FakeChannelExtractionThread,
-)
 from allencell_ml_segmenter.core.channel_extraction import (
     ChannelExtractionThread,
     get_img_path_from_csv,


### PR DESCRIPTION
**Objective:** Remove remaining artifacts from `Asyncio` usage.  

**Background:** This was never really part of the plugin design, but may have been a misunderstanding caused by a feature of the `cto-dl` API.  Basically, `View.doWord` runs in a background thread, and is down the callstack from where we call `cyto_api.predict` so it doesnt make sense to submit the actual work from that thread to a coroutine, and have the thread sit there idle.

**Testing:** Manual.  Everything still works as expected, however the console output _is_ a bit different, which surprised me.  Maybe due to a different code path in `cyto_api.predict()` ?

 
![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/1c2cc886-1826-4c69-9c4a-a65d5528b75f)
