### PR TITLE
existing experiment combo is cleared on radio change

### DIFF
--- a/src/allencell_ml_segmenter/training/model_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/model_selection_widget.py
@@ -262,6 +262,7 @@ class ModelSelectionWidget(QWidget):
         self._combo_box_existing_models.addItems(
             self._experiments_model.get_experiments()
         )
+        self._combo_box_existing_models.setCurrentIndex(-1)
         self._combo_box_existing_models.setPlaceholderText(
             "No existing models"
             if self._experiments_model.get_experiments() == []


### PR DESCRIPTION
On load:
![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/714d79e0-eba9-4c3a-8e8c-f2f7a18d49d6)
On radio selection:
![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/4a5c933d-f910-4766-bfe1-06699e1b9520)
On combo selection:
![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/7348650/88f7f5ee-4fd1-4c58-900c-dd18a63b3328)

Previously, the first choice was selected, and the Apply button was not enabled.  This was annoying because you would need to change the selection for the Apply button to enable, and if you wanted the first choice, you had to change it back.