### PR TITLE
Add self hosted runner, pin version of importlib-metadata that works

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build twine
+# importlib 8.0.0 is broken, we should be able to un-pin this once 8.0.1 is released
           pip install importlib_metadata==7.2.1
     
       - name: Build Package


### PR DESCRIPTION
(sorry for the pr spam, theres really no other way to test this)
Two changes:

First change is due to this error on release https://github.com/AllenCell/allencell-ml-segmenter/actions/runs/9669994434/job/26677772688

Looks like its due to `importlib-metadata`, a new version was released 3 hours ago and people are reporting the exact same issue on `twine`'s gh issues page https://github.com/pypa/twine/issues/977.

It looks like its getting worked on, but for now, pinning previous version of `importlib-metadata` which has been found to resolve: https://github.com/pypa/twine/issues/977#issuecomment-2189800841


Second change: also found out that we need to host this on a self-hosted runner for publishing to artifactory. Otherwise we'd hit a DNS error on the artifactory url:
![image](https://github.com/AllenCell/allencell-ml-segmenter/assets/43979182/d98a6f0c-54d5-4511-a5e8-57467410e99b)
