### PR TITLE
pip installing plugin on artifactory grabs a yanked version of scikit-image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "tifffile>=2023.4.12",
     "watchdog",
     "cyto-dl>=0.1.7",
+    "scikit-image!=0.23.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Clare + Thao have this issue when pip installing the plugin in a new conda env.
```
Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      + meson setup /private/var/folders/69/rwf61x491l56__tgmt_cf48r0000gq/T/pip-install-sa103r4b/scikit-image_820edc3a56444dc8ace2835a2f04bd66 /private/var/folders/69/rwf61x491l56__tgmt_cf48r0000gq/T/pip-install-sa103r4b/scikit-image_820edc3a56444dc8ace2835a2f04bd66/.mesonpy-_6ow2ty3 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/private/var/folders/69/rwf61x491l56__tgmt_cf48r0000gq/T/pip-install-sa103r4b/scikit-image_820edc3a56444dc8ace2835a2f04bd66/.mesonpy-_6ow2ty3/meson-python-native-file.ini
      The Meson build system
      Version: 1.4.1
      Source dir: /private/var/folders/69/rwf61x491l56__tgmt_cf48r0000gq/T/pip-install-sa103r4b/scikit-image_820edc3a56444dc8ace2835a2f04bd66
      Build dir: /private/var/folders/69/rwf61x491l56__tgmt_cf48r0000gq/T/pip-install-sa103r4b/scikit-image_820edc3a56444dc8ace2835a2f04bd66/.mesonpy-_6ow2ty3
      Build type: native build
      Project name: scikit-image
      Project version: 0.23.0
      
      ../meson.build:1:0: ERROR: Unknown compiler(s): [['cc'], ['gcc'], ['clang'], ['nvc'], ['pgcc'], ['icc'], ['icx']]
      The following exception(s) were encountered:
      Running `nvc --version` gave "[Errno 2] No such file or directory: 'nvc'"
      Running `pgcc --version` gave "[Errno 2] No such file or directory: 'pgcc'"
      Running `icc --version` gave "[Errno 2] No such file or directory: 'icc'"
      Running `icx --version` gave "[Errno 2] No such file or directory: 'icx'"
      
      A full log can be found at /private/var/folders/69/rwf61x491l56__tgmt_cf48r0000gq/T/pip-install-sa103r4b/scikit-image_820edc3a56444dc8ace2835a2f04bd66/.mesonpy-_6ow2ty3/meson-logs/meson-log.txt
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

[notice] A new release of pip is available: 23.0 -> 24.1.1
[notice] To update, run: pip install --upgrade pip
```

**EDIT**: I talked with @pgarrison yesterday and I have a better understanding of whats going on.

The source of this issue is Artifactory- our local artifactory server doesnt support "yanked" python packages, so pip will still grab yanked versions of libraries, which is why we're seeing clare and thaos installs grab `scikit-image==0.23.0`. This is a yanked version of scikit-image which does not have a build for python 3.10 and so pip tries to build this from source, which is why we are seeing the c compiler errors.

(Pip is not grabbing the latest version of  `scikit-image==0.24.0` because bioio requires a older version of `imageio` while `scikit-image==0.24.0` requires a newer version. For now not an issue, but if we ever update scikit-image to the latest version it would be an issue)

Once this is on pypi, we wont have this issue (it would automatically know to ignore `0.23.0` and get `0.22.0`), but while this is on artifactory, we need to explicitly specify `scikit-image!=0.23.0`
