### PR TITLE
Enforce no timeseries images

### DIFF
--- a/src/allencell_ml_segmenter/core/image_data_extractor/aics_image_data_extractor.py
+++ b/src/allencell_ml_segmenter/core/image_data_extractor/aics_image_data_extractor.py
@@ -31,7 +31,7 @@ class AICSImageDataExtractor(IImageDataExtractor):
         aics_img: AICSImage = AICSImage(img_path)
         if aics_img.dims.T > 1:
             raise RuntimeError("Cannot load timeseries images")
-        
+
         img_data = None
         if np_data:
             img_data = aics_img.get_image_dask_data("ZYX", C=channel).compute()


### PR DESCRIPTION
## Context
#381 . This PR causes napari error messages to appear when a user tries to use timeseries images for curation, training, or prediction. The error will show up as in the screenshot below:

<img width="527" alt="Screenshot 2024-07-02 at 4 13 18 PM" src="https://github.com/AllenCell/allencell-ml-segmenter/assets/32145612/6c91edae-9f13-4bca-bd79-818ff8aefa96">

## Testing
Manual testing.