### PR TITLE
Dont show training finished when training never really started

### DIFF
--- a/src/allencell_ml_segmenter/services/training_service.py
+++ b/src/allencell_ml_segmenter/services/training_service.py
@@ -92,6 +92,7 @@ class TrainingService(Subscriber):
                 )
             )
             model.train()
+            self._training_model.set_training_completed(True)
 
     def _able_to_continue_training(self) -> bool:
         if self._experiments_model.get_experiment_name() is None:

--- a/src/allencell_ml_segmenter/training/training_model.py
+++ b/src/allencell_ml_segmenter/training/training_model.py
@@ -78,6 +78,8 @@ class TrainingModel(Publisher):
         self._model_size: Optional[ModelSize] = None
         # the total number of images used for training/test/validation for this model
         self._total_num_images: int = 0
+        # training started, then finished
+        self._training_completed: bool = False
 
     def get_experiment_type(self) -> Optional[str]:
         """
@@ -241,3 +243,9 @@ class TrainingModel(Publisher):
 
     def get_total_num_images(self) -> int:
         return self._total_num_images
+
+    def set_training_completed(self, completed: bool) -> None:
+        self._training_completed = completed
+
+    def get_training_completed(self) -> bool:
+        return self._training_completed

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -254,6 +254,8 @@ class TrainingView(View, MainWindow):
         """
         Starts training process
         """
+        # reset training completed to False since just starting out
+        self._training_model.set_training_completed(False)
         self._training_model.dispatch_training()
 
     def getTypeOfWork(self) -> str:
@@ -263,8 +265,9 @@ class TrainingView(View, MainWindow):
         return "Training"
 
     def showResults(self):
-        dialog_box = InfoDialogBox("Training finished")
-        dialog_box.exec()
+        if self._training_model.get_training_completed():
+            dialog_box = InfoDialogBox("Training finished")
+            dialog_box.exec()
 
     def _num_epochs_field_handler(self, num_epochs: str) -> None:
         self._training_model.set_num_epochs(int(num_epochs))


### PR DESCRIPTION
There are two ways to do this IMO and I picked the simple route:

In the model I'm storing `training_completed` as state, and when the training task is called I'm setting `training_completed=True` afterwards. The training complete dialog is only shown when this flag is set.
Future work: In the error reporting from training thread ticket, if any errors occur during training this would not be set to `True` and also not show a training complete dialog, and an error message would be shown instead.

Alternatively I could use the TrainingProgressTracker to see when we've completed training, and set this flag that way

