### PR TITLE
Pyside fixes

### DIFF
--- a/src/allencell_ml_segmenter/curation/stacked_spinner.py
+++ b/src/allencell_ml_segmenter/curation/stacked_spinner.py
@@ -12,7 +12,9 @@ class StackedSpinner(QStackedWidget):
     def __init__(self, input_button: InputButton = None):
         super().__init__()
 
-        self.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
+        self.setSizePolicy(
+            QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum
+        )
         if input_button is not None:
             self.resize(input_button.width(), input_button.height())
         else:


### PR DESCRIPTION
## Context
#230 . Contains one minor fix which allows `PySide6` (experimental) to run without problems**.

## Findings
- `PySide6` did not like how we were setting the size policy in `stacked_spinner.py`, so I fixed that--tested on both `PySide6` and `PyQt5` successfully.
- **Segfaults**... when I used `PySide6` I was able to produce segfaults in a variety of situations (on loading images in curation, on loading channels in prediction, on exiting the napari window). I suspect this has something to do with `napari` not interacting well with `Qt6` (which is what backs `PySide6`). Note: I was able to produce segfaults on `PySide6==6.7.2` and `PySide6==6.4.3`. I tried similar UI interaction patterns with `PyQt5` and was not able to produce segfaults. I wanted to confirm my theory by testing a `PySide` version backed by `Qt5`; unfortunately for these versions there is no wheel built for ARM64, so I can't test it without jumping through a bunch of hoops.

## Next steps
If we decide we are concerned about `PySide6` segfaults, we should confirm on a non-ARM64 machine that `PySide2` (which confusingly uses `Qt5`) does not produce segfaults. The most reliable way I was able to get a segfault was by spam clicking the next button during curation with large multi-channel images.