### PR TITLE
disabled tab style

### DIFF
--- a/src/allencell_ml_segmenter/styles/core.qss
+++ b/src/allencell_ml_segmenter/styles/core.qss
@@ -58,6 +58,6 @@ QComboBox:disabled {
     margin: 10px 0px;
 }
 
-QTabBar::tab:!selected {
+QTabBar::tab:disabled:!selected {
     color: #868E93;
 }


### PR DESCRIPTION
@thao-do found that users were not able to tell that they cannot select our disabled tabs.  This PR adjusts the style to make the disabled status more apparent.

Before:
![image](https://github.com/user-attachments/assets/78705452-4e54-46de-934e-0e50b0a370be)

After:
![image](https://github.com/user-attachments/assets/0565b089-69c1-445e-9d70-f225764458b7)

