### PR TITLE
pin cyto-dl==0.1.8 until iterative training released

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test_lint = [
     "black>=24.2.0",
     'pytest-xvfb; sys_platform == "linux"',
     "responses",
-    "mypy",
+    "mypy<1.11.2",
 ]
 
 dev = [
@@ -77,7 +77,7 @@ dev = [
     "build>=1.0.3",
     "twine>=5.0.0",
     "responses",
-    "mypy<=1.11.1",
+    "mypy<1.11.2",
 ]
 
 # entry points


### PR DESCRIPTION
`cyto-dl==0.3.0` contains config changes required to support iterative learning- but they break the current configs we have on s3.

For now, until we release iterative training, we should just use `0.1.8`. I will specify `cyto-dl>=0.3.0` with my iterative learning changes, and update the configs on s3 as we release iterative learning.