### PR TITLE
Fix watchdog typing errors

### DIFF
--- a/src/allencell_ml_segmenter/prediction/prediction_folder_event_handler.py
+++ b/src/allencell_ml_segmenter/prediction/prediction_folder_event_handler.py
@@ -18,6 +18,7 @@ class PredictionFolderEventHandler(FileSystemEventHandler):
 
     # override
     def on_created(self, event: FileSystemEvent) -> None:
-        if any([event.src_path.endswith(ext) for ext in self.PRED_FILE_EXTS]):
+        src_path: str = str(event.src_path)
+        if any([src_path.endswith(ext) for ext in self.PRED_FILE_EXTS]):
             self._num_pred_files_created += 1
             self._progress_callback(self._num_pred_files_created)

--- a/src/allencell_ml_segmenter/prediction/prediction_folder_progress_tracker.py
+++ b/src/allencell_ml_segmenter/prediction/prediction_folder_progress_tracker.py
@@ -40,7 +40,9 @@ class PredictionFolderProgressTracker(ProgressTracker):
             PredictionFolderEventHandler(self.set_progress)
         )
         self._observer.schedule(
-            event_handler, path=self._prediction_folder_path, recursive=False
+            event_handler,
+            path=str(self._prediction_folder_path.resolve()),
+            recursive=False,
         )
         self._observer.start()
 

--- a/src/allencell_ml_segmenter/training/cache_dir_event_handler.py
+++ b/src/allencell_ml_segmenter/training/cache_dir_event_handler.py
@@ -19,6 +19,6 @@ class CacheDirEventHandler(FileSystemEventHandler):
 
     # override
     def on_created(self, event: FileSystemEvent) -> None:
-        if event.src_path.endswith(".pt"):
+        if str(event.src_path).endswith(".pt"):
             self._num_files += 1
             self._progress_callback(self._num_files)

--- a/src/allencell_ml_segmenter/training/metrics_csv_event_handler.py
+++ b/src/allencell_ml_segmenter/training/metrics_csv_event_handler.py
@@ -44,7 +44,7 @@ class MetricsCSVEventHandler(FileSystemEventHandler):
     # override
     def on_any_event(self, event: FileSystemEvent) -> None:
         if self._target_path.exists() and self._target_path.samefile(
-            event.src_path
+            str(event.src_path)
         ):
             epochs, loss = self._get_csv_data()
             self._progress_callback(epochs)

--- a/src/allencell_ml_segmenter/training/training_progress_tracker.py
+++ b/src/allencell_ml_segmenter/training/training_progress_tracker.py
@@ -73,13 +73,13 @@ class TrainingProgressTracker(ProgressTracker):
             self._target_path, self._set_progress, self.set_label_text
         )
         self._observer.schedule(
-            csv_handler, path=self._csv_path, recursive=True
+            csv_handler, path=str(self._csv_path.resolve()), recursive=True
         )
         cache_handler: CacheDirEventHandler = CacheDirEventHandler(
             self._set_cache_progress_text
         )
         self._observer.schedule(
-            cache_handler, path=self._cache_path, recursive=True
+            cache_handler, path=str(self._cache_path.resolve()), recursive=True
         )
         self._observer.start()
 


### PR DESCRIPTION
## Context
Solution to failing mypy CI that @yrkim98 discovered. It looks like the latest watchdog version introduced some typing, which then broke our mypy checks on CI. This would not be reproducible unless you did a fresh install of segmenter requirements.

## Changes
I fixed the issues that were pointed out by mypy once I updated my entire environment.