### PR TITLE
Switch from dev to rc

### DIFF
--- a/.github/workflows/bump_version_pr.yaml
+++ b/.github/workflows/bump_version_pr.yaml
@@ -14,7 +14,7 @@ on:
           - major
           - minor
           - patch
-          - dev
+          - rc
 
 jobs:
   publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ where = ["src"]
 # https://pypi.org/project/bumpver
 [tool.bumpver]
 current_version = "0.1.16"
-version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
+version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true
 tag             = false # no longer useful to tag here, must happen in create_publish_pr.yaml

--- a/src/allencell_ml_segmenter/_tests/scripts/pyproject.toml
+++ b/src/allencell_ml_segmenter/_tests/scripts/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 # https://pypi.org/project/bumpver
 [tool.bumpver]
 current_version = "0.0.1"
-version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
+version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit          = false
 tag             = false # no longer useful to tag here, must happen in create_publish_pr.yaml
 push            = false

--- a/src/allencell_ml_segmenter/_tests/scripts/test_bumpver_handler.py
+++ b/src/allencell_ml_segmenter/_tests/scripts/test_bumpver_handler.py
@@ -103,20 +103,20 @@ def test_bump_major() -> None:
     navigate_back_to_root_dir()
 
 
-def test_bump_dev() -> None:
+def test_bump_rc() -> None:
     navigate_to_test_dir_and_reset_version()
     # ASSERT (sanity check)
     assert_curr_version_number(DEFAULT_START_VERSION)
-    # ACT (create new patch version with .dev0 tag)
-    sys.argv = ["bumpver_handler.py", "dev"]
+    # ACT (create new patch version with .rc0 tag)
+    sys.argv = ["bumpver_handler.py", "rc"]
     bumpver_handler.main()
     # ASSERT
-    assert_curr_version_number("0.0.2.dev0")
+    assert_curr_version_number("0.0.2rc0")
     # ACT
-    sys.argv = ["bumpver_handler.py", "dev"]
+    sys.argv = ["bumpver_handler.py", "rc"]
     bumpver_handler.main()
     # ASSERT
-    assert_curr_version_number("0.0.2.dev1")
+    assert_curr_version_number("0.0.2rc1")
     # ACT (finalize the new patch version)
     sys.argv = ["bumpver_handler.py", "patch"]
     bumpver_handler.main()
@@ -133,24 +133,24 @@ def test_bump_post() -> None:
     sys.argv = ["bumpver_handler.py", "post"]
     bumpver_handler.main()
     # ASSERT
-    assert_curr_version_number("0.0.1.post0")
+    assert_curr_version_number("0.0.1post0")
     # ACT
     sys.argv = ["bumpver_handler.py", "post"]
     bumpver_handler.main()
     # ASSERT
-    assert_curr_version_number("0.0.1.post1")
+    assert_curr_version_number("0.0.1post1")
     navigate_back_to_root_dir()
 
 
-def test_bump_minor_fails_when_dev_current() -> None:
+def test_bump_minor_fails_when_rc_current() -> None:
     navigate_to_test_dir_and_reset_version()
     # ASSERT (sanity check)
     assert_curr_version_number(DEFAULT_START_VERSION)
-    # ACT (create new dev version with .dev0 tag)
-    sys.argv = ["bumpver_handler.py", "dev"]
+    # ACT (create new rc version with .rc0 tag)
+    sys.argv = ["bumpver_handler.py", "rc"]
     bumpver_handler.main()
     # ASSERT (sanity check)
-    assert_curr_version_number("0.0.2.dev0")
+    assert_curr_version_number("0.0.2rc0")
 
     got_expected_exception: bool = False
     try:
@@ -166,15 +166,15 @@ def test_bump_minor_fails_when_dev_current() -> None:
     navigate_back_to_root_dir()
 
 
-def test_bump_major_fails_when_dev_current() -> None:
+def test_bump_major_fails_when_rc_current() -> None:
     navigate_to_test_dir_and_reset_version()
     # ASSERT (sanity check)
     assert_curr_version_number(DEFAULT_START_VERSION)
-    # ACT (create new dev version with .dev0 tag)
-    sys.argv = ["bumpver_handler.py", "dev"]
+    # ACT (create new rc version with .rc0 tag)
+    sys.argv = ["bumpver_handler.py", "rc"]
     bumpver_handler.main()
     # ASSERT (sanity check)
-    assert_curr_version_number("0.0.2.dev0")
+    assert_curr_version_number("0.0.2rc0")
 
     got_expected_exception: bool = False
     try:
@@ -190,15 +190,15 @@ def test_bump_major_fails_when_dev_current() -> None:
     navigate_back_to_root_dir()
 
 
-def test_bump_post_fails_when_dev_current() -> None:
+def test_bump_post_fails_when_rc_current() -> None:
     navigate_to_test_dir_and_reset_version()
     # ASSERT (sanity check)
     assert_curr_version_number(DEFAULT_START_VERSION)
-    # ACT (create new dev version with .dev0 tag)
-    sys.argv = ["bumpver_handler.py", "dev"]
+    # ACT (create new rc version with .rc0 tag)
+    sys.argv = ["bumpver_handler.py", "rc"]
     bumpver_handler.main()
     # ASSERT (sanity check)
-    assert_curr_version_number("0.0.2.dev0")
+    assert_curr_version_number("0.0.2rc0")
 
     got_expected_exception: bool = False
     try:
@@ -222,7 +222,7 @@ def test_bump_minor_fails_when_post_current() -> None:
     sys.argv = ["bumpver_handler.py", "post"]
     bumpver_handler.main()
     # ASSERT (sanity check)
-    assert_curr_version_number("0.0.1.post0")
+    assert_curr_version_number("0.0.1post0")
 
     got_expected_exception: bool = False
     try:
@@ -246,7 +246,7 @@ def test_bump_major_fails_when_post_current() -> None:
     sys.argv = ["bumpver_handler.py", "post"]
     bumpver_handler.main()
     # ASSERT (sanity check)
-    assert_curr_version_number("0.0.1.post0")
+    assert_curr_version_number("0.0.1post0")
 
     got_expected_exception: bool = False
     try:
@@ -270,7 +270,7 @@ def test_bump_patch_fails_when_post_current() -> None:
     sys.argv = ["bumpver_handler.py", "post"]
     bumpver_handler.main()
     # ASSERT (sanity check)
-    assert_curr_version_number("0.0.1.post0")
+    assert_curr_version_number("0.0.1post0")
 
     got_expected_exception: bool = False
     try:
@@ -286,7 +286,7 @@ def test_bump_patch_fails_when_post_current() -> None:
     navigate_back_to_root_dir()
 
 
-def test_bump_dev_fails_when_post_current() -> None:
+def test_bump_rc_fails_when_post_current() -> None:
     navigate_to_test_dir_and_reset_version()
     # ASSERT (sanity check)
     assert_curr_version_number(DEFAULT_START_VERSION)
@@ -294,11 +294,11 @@ def test_bump_dev_fails_when_post_current() -> None:
     sys.argv = ["bumpver_handler.py", "post"]
     bumpver_handler.main()
     # ASSERT (sanity check)
-    assert_curr_version_number("0.0.1.post0")
+    assert_curr_version_number("0.0.1post0")
 
     got_expected_exception: bool = False
     try:
-        sys.argv = ["bumpver_handler.py", "dev"]
+        sys.argv = ["bumpver_handler.py", "rc"]
         bumpver_handler.main()
     except ValueError as e:
         got_expected_exception = True

--- a/src/allencell_ml_segmenter/_tests/scripts/unmodified_pyproject.toml
+++ b/src/allencell_ml_segmenter/_tests/scripts/unmodified_pyproject.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 # https://pypi.org/project/bumpver
 [tool.bumpver]
 current_version = "0.0.1"
-version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
+version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit          = false
 tag             = false # no longer useful to tag here, must happen in create_publish_pr.yaml
 push            = false


### PR DESCRIPTION
## Context
After some research, @hughes036 and I found that the `rc` tags are most commonly used to indicate pre-releases (not `dev`, which we've been using).

## Changes
1. update bumpver config in `pyproject.toml`
2. update `bumpver_handler.py` to use rc instead of dev
3. update options in bumpversion GH workflow

## Testing
Updated tests for `bumpver_handler.py`