### PR TITLE
publishing from public GHA runners

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,7 @@ env:
 jobs:
   publish:
     name: Publish
-    runs-on: [self-hosted, build]
+    runs-on: [build]
     environment: release
     permissions:
       id-token: write


### PR DESCRIPTION
Until now our publish workflow ran on our self-hosted runner so that it could PUT artifacts in Artifactory (private PYPI).  That is disallowed from public repos.  Now that this repo is public, we must run workflows on the public runners.  This means we can only publish to PYPI.  