### PR TITLE
Bugfix/enforce model trained once

### DIFF
--- a/src/allencell_ml_segmenter/main/main_model.py
+++ b/src/allencell_ml_segmenter/main/main_model.py
@@ -85,4 +85,3 @@ class MainModel(Publisher):
 
     def training_complete(self) -> None:
         self.dispatch(Event.PROCESS_TRAINING_COMPLETE)
-

--- a/src/allencell_ml_segmenter/main/main_model.py
+++ b/src/allencell_ml_segmenter/main/main_model.py
@@ -82,3 +82,7 @@ class MainModel(Publisher):
         ):
             self._selected_channels = new_channels
             self.signals.selected_channels_changed.emit()
+
+    def training_complete(self) -> None:
+        self.dispatch(Event.PROCESS_TRAINING_COMPLETE)
+

--- a/src/allencell_ml_segmenter/main/main_widget.py
+++ b/src/allencell_ml_segmenter/main/main_widget.py
@@ -148,7 +148,9 @@ class MainWidget(AicsWidget):
 
         # events for auto window switching
         self._model.subscribe(
-            Event.PROCESS_TRAINING_COMPLETE, self, self._disable_non_prediction_tabs
+            Event.PROCESS_TRAINING_COMPLETE,
+            self,
+            self._disable_non_prediction_tabs,
         )
 
     def _handle_experiment_applied(self, _: Event) -> None:

--- a/src/allencell_ml_segmenter/main/main_widget.py
+++ b/src/allencell_ml_segmenter/main/main_widget.py
@@ -148,7 +148,7 @@ class MainWidget(AicsWidget):
 
         # events for auto window switching
         self._model.subscribe(
-            Event.PROCESS_TRAINING_COMPLETE, self, self._handle_existing_model
+            Event.PROCESS_TRAINING_COMPLETE, self, self._disable_non_prediction_tabs
         )
 
     def _handle_experiment_applied(self, _: Event) -> None:
@@ -174,7 +174,7 @@ class MainWidget(AicsWidget):
             else self._prediction_view
         )
 
-    def _handle_existing_model(self, _: Event) -> None:
+    def _disable_non_prediction_tabs(self, _: Event) -> None:
         """
         Handle existing model selection (disable tabs).
 

--- a/src/allencell_ml_segmenter/main/main_widget.py
+++ b/src/allencell_ml_segmenter/main/main_widget.py
@@ -183,8 +183,8 @@ class MainWidget(AicsWidget):
         inputs:
             is_new_model - bool
         """
-        self._window_container.setTabDisabled(0, self._model.is_new_model())
-        self._window_container.setTabDisabled(1, self._model.is_new_model())
+        self._window_container.setTabEnabled(0, False)
+        self._window_container.setTabEnabled(1, False)
 
     def _handle_change_view(self, event: Event) -> None:
         """

--- a/src/allencell_ml_segmenter/main/main_widget.py
+++ b/src/allencell_ml_segmenter/main/main_widget.py
@@ -146,6 +146,13 @@ class MainWidget(AicsWidget):
         layout.addStretch(100)
         self.setStyleSheet(Style.get_stylesheet("core.qss"))
 
+        # events for auto window switching
+        self._model.subscribe(
+            Event.PROCESS_TRAINING_COMPLETE,
+            self,
+            self._handle_existing_model
+        )
+
     def _handle_experiment_applied(self, _: Event) -> None:
         """
         Handle the experiment applied event.
@@ -168,6 +175,16 @@ class MainWidget(AicsWidget):
             if self._model.is_new_model()
             else self._prediction_view
         )
+
+    def _handle_existing_model(self, _: Event) -> None:
+        """
+        Handle existing model selection (disable tabs).
+
+        inputs:
+            is_new_model - bool
+        """
+        self._window_container.setTabDisabled(0, self._model.is_new_model())
+        self._window_container.setTabDisabled(1, self._model.is_new_model())
 
     def _handle_change_view(self, event: Event) -> None:
         """

--- a/src/allencell_ml_segmenter/main/main_widget.py
+++ b/src/allencell_ml_segmenter/main/main_widget.py
@@ -148,9 +148,7 @@ class MainWidget(AicsWidget):
 
         # events for auto window switching
         self._model.subscribe(
-            Event.PROCESS_TRAINING_COMPLETE,
-            self,
-            self._handle_existing_model
+            Event.PROCESS_TRAINING_COMPLETE, self, self._handle_existing_model
         )
 
     def _handle_experiment_applied(self, _: Event) -> None:

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -298,12 +298,18 @@ class TrainingView(View, MainWindow):
 
     def showResults(self) -> None:
         # double check to see if a ckpt was generated
-        exp_path: Optional[Path] = self._experiments_model.get_user_experiments_path()
+        exp_path: Optional[Path] = (
+            self._experiments_model.get_user_experiments_path()
+        )
         if exp_path is None:
-            raise ValueError("Experiments path should not be None after training complete.")
+            raise ValueError(
+                "Experiments path should not be None after training complete."
+            )
         exp_name: Optional[str] = self._experiments_model.get_experiment_name()
         if exp_name is None:
-            raise ValueError("Experiment name should not be None after training complete.")
+            raise ValueError(
+                "Experiment name should not be None after training complete."
+            )
         ckpt_generated: Optional[Path] = ExperimentUtils.get_best_ckpt(
             exp_path,
             exp_name,

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -299,7 +299,7 @@ class TrainingView(View, MainWindow):
     def showResults(self) -> None:
         # double check to see if a ckpt was generated
         ckpt_generated: Optional[Path] = ExperimentUtils.get_best_ckpt(
-            self._experiments_model.get_user_experiments_path,
+            self._experiments_model.get_user_experiments_path(),
             self._experiments_model.get_experiment_name())
         if ckpt_generated is not None:
             # if model was successfully trained, get metrics to display

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -330,8 +330,8 @@ class TrainingView(View, MainWindow):
             dialog_box = InfoDialogBox(
                 "Training finished -- Final loss: {:.3f}".format(min_loss)
             )
-            dialog_box.exec() # this shows the dialog box
-            self._main_model.training_complete() # this dispatches the event that changes to prediction tab
+            dialog_box.exec()  # this shows the dialog box
+            self._main_model.training_complete()  # this dispatches the event that changes to prediction tab
         else:
             dialog_box = InfoDialogBox(
                 "Training failed- no model was saved from this run."

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -330,8 +330,8 @@ class TrainingView(View, MainWindow):
             dialog_box = InfoDialogBox(
                 "Training finished -- Final loss: {:.3f}".format(min_loss)
             )
-            dialog_box.exec()
-            self._main_model.training_complete()
+            dialog_box.exec() # this shows the dialog box
+            self._main_model.training_complete() # this dispatches the event that changes to prediction tab
         else:
             dialog_box = InfoDialogBox(
                 "Training failed- no model was saved from this run."

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -298,9 +298,16 @@ class TrainingView(View, MainWindow):
 
     def showResults(self) -> None:
         # double check to see if a ckpt was generated
+        exp_path: Optional[Path] = self._experiments_model.get_user_experiments_path()
+        if exp_path is None:
+            raise ValueError("Experiments path should not be None after training complete.")
+        exp_name: Optional[str] = self._experiments_model.get_experiment_name()
+        if exp_name is None:
+            raise ValueError("Experiment name should not be None after training complete.")
         ckpt_generated: Optional[Path] = ExperimentUtils.get_best_ckpt(
-            self._experiments_model.get_user_experiments_path(),
-            self._experiments_model.get_experiment_name())
+            exp_path,
+            exp_name,
+        )
         if ckpt_generated is not None:
             # if model was successfully trained, get metrics to display
             csv_path: Optional[Path] = (
@@ -308,7 +315,9 @@ class TrainingView(View, MainWindow):
             )
             if csv_path is None:
                 raise RuntimeError("Cannot get min loss from undefined csv")
-            min_loss: Optional[float] = FileUtils.get_min_loss_from_csv(csv_path)
+            min_loss: Optional[float] = FileUtils.get_min_loss_from_csv(
+                csv_path
+            )
             if min_loss is None:
                 raise RuntimeError("Cannot compute min loss")
 
@@ -322,7 +331,6 @@ class TrainingView(View, MainWindow):
                 "Training failed- no model was saved from this run."
             )
             dialog_box.exec()
-
 
     def _num_epochs_field_handler(self, num_epochs: str) -> None:
         self._training_model.set_num_epochs(int(num_epochs))


### PR DESCRIPTION
UI changes to enforce that the user can only train a model once. Will automatically switch to prediction tab and disable curation/training once plugin is able to verify a model was sucessfully trained.

Changes:

- src/allencell_ml_segmenter/main/main_model.py: Dispatch training complete event
- src/allencell_ml_segmenter/main/main_widget.py: Subscribe to event and disable tabs when training complete
- src/allencell_ml_segmenter/training/view.py: Add check to see if training completed successfully, and dispatch event if so