### PR TITLE
version pin for iterative training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "bioio",
     "tifffile>=2023.4.12",
     "watchdog",
-    "cyto-dl>=0.1.8",
+    "cyto-dl>=0.3.0",
     "scikit-image!=0.23.0",
 ]
 


### PR DESCRIPTION
Just pinning cyto-dl version needed for iterative training. We'll use a separate branch for testing with the staging bucket- for now.