### PR TITLE
Automate tickets created

### DIFF
--- a/.github/workflows/auto_add_dev_tickets_to_project.yaml
+++ b/.github/workflows/auto_add_dev_tickets_to_project.yaml
@@ -1,0 +1,19 @@
+name: Auto add dev tickets to project board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check labels and add to project
+        if: |
+          !contains(github.event.issue.labels.*.name, 'Requests') &&
+          !contains(github.event.issue.labels.*.name, 'Bug Reports')
+        uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/AllenCell/projects/7
+          content-id: ${{ github.event.issue.node_id }}
+          column-name: Backlog

--- a/.github/workflows/auto_add_feature_request_to_project.yaml
+++ b/.github/workflows/auto_add_feature_request_to_project.yaml
@@ -1,0 +1,19 @@
+name: Auto-add feature requests and bug reports to project board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    if: |
+          contains(github.event.issue.labels.*.name, 'Requests') ||
+          contains(github.event.issue.labels.*.name, 'Bug Reports')
+    steps:
+      - name: Add issue to project
+        uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/AllenCell/projects/9
+          content-id: ${{ github.event.issue.node_id }}
+          column-name: Scoping


### PR DESCRIPTION
Added two workflow files:

- `auto_add_dev_tickets_to_project.yaml` should add all github issues not created with a "Requests" or "Bug Reports" label to the first swimlane of the feature requests board. The new feature templates will make it so that these labels get automatically applied to all feature requests or bug reports submitted
- `auto_add_feature_request_to_project.yaml` should add all github issues without the "Requests" and "Bug Reports" label to the first swimlane of the dev board. This will be for when we create dev tickets to work on. We should not label these as "Requests" or "Bug Reports"