### PR TITLE
pre trained models doc for metadata

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,5 @@
+### Pre-Trained Models
+
+Megaseg
+
+Megaseg-lite

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,5 +1,22 @@
 ### Pre-Trained Models
 
-Megaseg
-
-Megaseg-lite
+| Category           | Name              | MegaSeg_v1                                                                                  | MegaSeg_light                                                          |
+|--------------------|-------------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| **Model Properties**   | Description       | CNN-based segmentation model trained on 2600 open 3D fluorescent microscopy images of cellular structures in human hiPSCs | Lighter version of MegaSeg which compromises accuracy for speed       |
+|                    | Architecture       | nnUNet                                                                                      | small nnUNet with fewer kernels                                       |
+|                    | Loss Function      | Generalized dice focal loss                                                                 | Generalized dice focal loss                                           |
+|                    | Optimization       | Adam                                                                                        | Adam                                                                  |
+|                    | # of Epochs        | 1000                                                                                        | 1000                                                                  |
+|                    | Stopping Criteria  | Validation loss not improving for 100 epochs                                               | Validation loss not improving for 100 epochs                          |
+|                    | System Trained On  | Nvidia A100                                                                                | Nvidia A100                                                           |
+|                    | Validation Step    | -                                                                                          | -                                                                     |
+| **Dependencies**   | CytoDL Version     | 1.7.1                                                                                       | 1.7.1                                                                 |
+|                    | PyTorch Version    | 2.4.0+cu118                                                                                | 2.4.0+cu118                                                           |
+| **Training Data**  | Image Resolution   | 55x624x924; 60x624x924; 65x600x900; 65x624x924; 70x624x924; 75x624x924; 75x600x900         | 55x624x924; 60x624x924; 65x600x900; 65x624x924; 70x624x924; 75x624x924; 75x600x900 |
+|                    | Minimum Image Size | -                                                                                          | -                                                                     |
+|                    | Microscope Objective | 100x                                                                                    | 100x                                                                  |
+|                    | Microscopy Technique | Spinning disk confocal                                                                    | Spinning disk confocal                                                |
+|                    | Public Data Link   | [Dataset Link](https://open.quiltdata.com/b/allencell/tree/aics/hipsc_single_cell_image_dataset/) | [Dataset Link](https://open.quiltdata.com/b/allencell/tree/aics/hipsc_single_cell_image_dataset/) |
+|                    | Expected Performance | On NVIDIA-A100, 80GB, Inference @ 6.01 Secs for an Input image of size 924x624x65        | On NVIDIA-A100, 80GB, Inference @ 2.32 Secs for an Input image of size 924x624x65 |
+|                    | Structures Trained On | Actin bundles, ER(SERCA2), Adherens junctions, Desmosomes, Gap junctions, Myosin, Nuclear pores, Endosomes, ER (SEC61 Beta), Nuclear speckles, Golgi, Tight junctions, Mitochondria | Actin bundles, ER(SERCA2), Adherens junctions, Desmosomes, Gap junctions, Myosin, Nuclear pores, Endosomes, ER (SEC61 Beta), Nuclear speckles, Golgi, Tight junctions, Mitochondria |
+| **Inference Data** | Minimum Image Dimension | 16x16x16                                                                            | 16x16x16                                                              |

--- a/src/allencell_ml_segmenter/widgets/model_download_dialog.py
+++ b/src/allencell_ml_segmenter/widgets/model_download_dialog.py
@@ -46,16 +46,16 @@ class ModelDownloadDialog(QDialog):
 
         self._download_button.clicked.connect(self._download_button_handler)
         self._doc_button.clicked.connect(self._doc_button_handler)
-        
+
         layout.addWidget(self._doc_button)
         layout.addWidget(self._model_select_dropdown)
         layout.addWidget(self._download_button)
 
     def _doc_button_handler(self) -> None:
         webbrowser.open(
-                "https://github.com/AllenCell/allencell-segmenter-ml/blob/main/docs/models.md"
-            )
-        
+            "https://github.com/AllenCell/allencell-segmenter-ml/blob/main/docs/models.md"
+        )
+
     def _download_button_handler(self) -> None:
         selected_model_name: str = str(
             self._model_select_dropdown.currentText()

--- a/src/allencell_ml_segmenter/widgets/model_download_dialog.py
+++ b/src/allencell_ml_segmenter/widgets/model_download_dialog.py
@@ -1,5 +1,6 @@
 from typing import Optional
 from pathlib import Path
+import webbrowser
 
 from qtpy.QtWidgets import (
     QDialog,
@@ -39,12 +40,22 @@ class ModelDownloadDialog(QDialog):
         self._model_select_dropdown: QComboBox = QComboBox()
         self._model_select_dropdown.setCurrentIndex(-1)
         self._model_select_dropdown.addItems(self._available_models.keys())
-        layout.addWidget(self._model_select_dropdown)
 
         self._download_button: QPushButton = QPushButton("Download")
+        self._doc_button: QPushButton = QPushButton("Documentation")
+
         self._download_button.clicked.connect(self._download_button_handler)
+        self._doc_button.clicked.connect(self._doc_button_handler)
+        
+        layout.addWidget(self._doc_button)
+        layout.addWidget(self._model_select_dropdown)
         layout.addWidget(self._download_button)
 
+    def _doc_button_handler(self) -> None:
+        webbrowser.open(
+                "https://github.com/AllenCell/allencell-segmenter-ml/blob/535-model-metadata/docs/models.md" # noqa TODO update link
+            )
+        
     def _download_button_handler(self) -> None:
         selected_model_name: str = str(
             self._model_select_dropdown.currentText()

--- a/src/allencell_ml_segmenter/widgets/model_download_dialog.py
+++ b/src/allencell_ml_segmenter/widgets/model_download_dialog.py
@@ -53,7 +53,7 @@ class ModelDownloadDialog(QDialog):
 
     def _doc_button_handler(self) -> None:
         webbrowser.open(
-                "https://github.com/AllenCell/allencell-segmenter-ml/blob/535-model-metadata/docs/models.md" # noqa TODO update link
+                "https://github.com/AllenCell/allencell-segmenter-ml/blob/main/docs/models.md"
             )
         
     def _download_button_handler(self) -> None:


### PR DESCRIPTION
Simple button in models dialog launched our doc hosted in GH:

![image](https://github.com/user-attachments/assets/aa736d58-84e3-47a1-9605-a3c5b26a0370)

![image](https://github.com/user-attachments/assets/112c3ab5-602a-40f6-b14b-3e3523e941db)

TODO

UX review of this feature @thao-do 

Add model metadata content to https://github.com/AllenCell/allencell-segmenter-ml/blob/535-model-metadata/docs/models.md @smishra3 @amilworks 
