### PR TITLE
Iterative training hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "bioio",
     "tifffile>=2023.4.12",
     "watchdog",
-    "cyto-dl>=0.3.0",
+    "cyto-dl>=0.4.1",
     "scikit-image!=0.23.0",
 ]
 

--- a/src/allencell_ml_segmenter/_tests/services/test_prediction_service.py
+++ b/src/allencell_ml_segmenter/_tests/services/test_prediction_service.py
@@ -134,7 +134,7 @@ def test_build_overrides() -> None:
     assert overrides["train"] == False
     assert overrides["mode"] == "predict"
     assert overrides["task_name"] == "predict_task_from_app"
-    assert overrides["ckpt_path"] == str(
+    assert overrides["checkpoint.ckpt_path"] == str(
         Path(__file__).parent.parent
         / "main"
         / "experiments_home"

--- a/src/allencell_ml_segmenter/main/experiments_model.py
+++ b/src/allencell_ml_segmenter/main/experiments_model.py
@@ -77,11 +77,7 @@ class ExperimentsModel(IExperimentsModel):
         return user_exp_path / experiment_name / "checkpoints" / checkpoint
 
     def _get_exp_path(self) -> Path:
-        user_exp_path: Optional[Path] = self.get_user_experiments_path()
-        exp_name: Optional[str] = self.get_experiment_name()
-        if user_exp_path is None or exp_name is None:
-            raise ValueError("Experiment path or name undefined")
-        return user_exp_path / exp_name
+        return self.get_user_experiments_path() / self.get_experiment_name()
 
     def get_csv_path(self) -> Path:
         return self._get_exp_path() / "data"

--- a/src/allencell_ml_segmenter/main/experiments_model.py
+++ b/src/allencell_ml_segmenter/main/experiments_model.py
@@ -77,7 +77,12 @@ class ExperimentsModel(IExperimentsModel):
         return user_exp_path / experiment_name / "checkpoints" / checkpoint
 
     def _get_exp_path(self) -> Path:
-        return self.get_user_experiments_path() / self.get_experiment_name()
+        user_exp_path: Optional[Path] = self.get_user_experiments_path()
+        exp_name: Optional[str] = self.get_experiment_name()
+        if user_exp_path and exp_name:
+            return user_exp_path / exp_name
+        else:
+            raise ValueError("get_exp_path called without both defined.")
 
     def get_csv_path(self) -> Path:
         return self._get_exp_path() / "data"

--- a/src/allencell_ml_segmenter/main/i_experiments_model.py
+++ b/src/allencell_ml_segmenter/main/i_experiments_model.py
@@ -29,6 +29,7 @@ class IExperimentsModel(Publisher):
 
         name (str): name of cyto-dl experiment
         """
+        print(f"applying {name} experiment")
         self._experiment_name = name
         self.dispatch(Event.ACTION_EXPERIMENT_APPLIED)
 

--- a/src/allencell_ml_segmenter/services/prediction_service.py
+++ b/src/allencell_ml_segmenter/services/prediction_service.py
@@ -135,7 +135,7 @@ class PredictionService(Subscriber):
         # Need these overrides to load in csv's
         overrides["data.columns"] = ["raw", "split"]
         overrides["data.split_column"] = "split"
-        overrides["ckpt_path"] = str(checkpoint)
+        overrides["checkpoint.ckpt_path"] = str(checkpoint)
 
         input_path: Optional[Path] = (
             self._prediction_model.get_input_image_path()

--- a/src/allencell_ml_segmenter/training/image_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/image_selection_widget.py
@@ -134,7 +134,10 @@ class ImageSelectionWidget(QWidget):
         self._model.signals.num_channels_set.connect(self._update_channels)
 
     def set_inputs_csv(self, event: Optional[Event] = None) -> None:
-        if self._experiments_model.get_user_experiments_path() and self._experiments_model.get_experiment_name():
+        if (
+            self._experiments_model.get_user_experiments_path()
+            and self._experiments_model.get_experiment_name()
+        ):
             csv_path = self._experiments_model.get_csv_path() / "train.csv"
             if csv_path.is_file():
                 # if the csv exists

--- a/src/allencell_ml_segmenter/training/image_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/image_selection_widget.py
@@ -134,7 +134,7 @@ class ImageSelectionWidget(QWidget):
         self._model.signals.num_channels_set.connect(self._update_channels)
 
     def set_inputs_csv(self, event: Optional[Event] = None) -> None:
-        if self._experiments_model.get_csv_path() is not None:
+        if self._experiments_model.get_user_experiments_path() and self._experiments_model.get_experiment_name():
             csv_path = self._experiments_model.get_csv_path() / "train.csv"
             if csv_path.is_file():
                 # if the csv exists

--- a/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
+++ b/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
@@ -62,6 +62,9 @@ class CytoDLOverridesManager:
                 )
             # Filters/Model Size (required if starting new model)
             overrides_dict["model._aux.filters"] = model_size.value
+            # needed to specify no weights used
+            overrides_dict["checkpoint.weights_only"] = False
+            overrides_dict["checkpoint.strict"] = True
 
         # Hardware overrides (required)
         if CUDAUtils.cuda_available():

--- a/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
+++ b/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
@@ -62,9 +62,6 @@ class CytoDLOverridesManager:
                 )
             # Filters/Model Size (required if starting new model)
             overrides_dict["model._aux.filters"] = model_size.value
-            # needed to specify no weights used
-            overrides_dict["checkpoint.weights_only"] = False
-            overrides_dict["checkpoint.strict"] = True
 
         # Hardware overrides (required)
         if CUDAUtils.cuda_available():


### PR DESCRIPTION
- This changes regular prediction runs to override the correct ckpt_path key in the cyto-dl config
- Also explicitly turns off iterative training- so we dont have to rely on cyto-dl configs to have iterative training turned off by default
- Update tests