### PR TITLE
Updating prediction for cyto-dl==0.4.1

### DIFF
--- a/src/allencell_ml_segmenter/prediction/model.py
+++ b/src/allencell_ml_segmenter/prediction/model.py
@@ -81,7 +81,7 @@ class PredictionModel(Publisher):
         Gets path to where segmentation predictions are stored.
         """
         return (
-            self._output_directory / "target"
+            self._output_directory / "seg"
             if self._output_directory is not None
             else None
         )

--- a/src/allencell_ml_segmenter/services/prediction_service.py
+++ b/src/allencell_ml_segmenter/services/prediction_service.py
@@ -157,10 +157,8 @@ class PredictionService(Subscriber):
         channel: Optional[int] = (
             self._prediction_model.get_image_input_channel_index()
         )
-        if channel:
-            overrides["data.transforms.predict.transforms[1].reader[0].C"] = (
-                channel
-            )
+        if channel is not None:
+            overrides["input_channel"] = channel
 
         # selecting hardware- GPU if available (and correct drivers installed),
         # CPU otherwise.


### PR DESCRIPTION
Changes

- Predictions are now saved to a 'seg' folder- so updating where we get the predictions from
- channel override is different
- when checking for channel override- explicitly check for `None` so we still override if a falsy value is provided (like channel 0) -> this way we do not rely on the configs having a channel 0 set by default.