### PR TITLE
pin latest cyto-dl version to fix iterative training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "bioio",
     "tifffile>=2023.4.12",
     "watchdog",
-    "cyto-dl>=0.4.1",
+    "cyto-dl>=0.4.2",
     "scikit-image!=0.23.0",
 ]
 


### PR DESCRIPTION
## Purpose
Version pinning latest `cyto-dl==0.4.2` which has the fixes for training from scratch.

## Changes
We are pinning the latest version of cyto-dl, 0.4.2

## Testing
Tested on windows

## How to review
One file change