### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @AllenCell/napari-plugins
+*   @AllenCell/napari-plugins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @hughes036 @yrkim98 @saeliddp
+* @AllenCell/napari-plugins


### PR DESCRIPTION
Using a Github Team as code owner.

## Purpose
Provide a mechanism for adding to / removing individuals as code owners without a code change. 

## Changes
CODEOWNERS is a team now

## Testing
None

## How to review
See 1 liner