### PR TITLE
default to batch size 1

### DIFF
--- a/src/allencell_ml_segmenter/services/prediction_service.py
+++ b/src/allencell_ml_segmenter/services/prediction_service.py
@@ -137,6 +137,9 @@ class PredictionService(Subscriber):
         overrides["data.split_column"] = "split"
         overrides["checkpoint.ckpt_path"] = str(checkpoint)
 
+        # This override is needed to for inference with cyto-dl, because we default to auto otherwise
+        overrides["data.batch_size"] = 1
+
         input_path: Optional[Path] = (
             self._prediction_model.get_input_image_path()
         )


### PR DESCRIPTION
## Purpose
Since we now specify batch size auto in our configs by default, we need this change.

from @benjijamorris 
> During training, we can assume all images are the same size because of the transforms we run to train on image patches. We can't assume that during inference because we're operating on full fovs instead of patches. The easy solution is to set the batch size to 1 during inference.

## Changes
We override to a batch size of 1

## Testing
We will run this through QC and I will test on the windows instance before our rc release

## How to review
one line change