### PR TITLE
Bugfix/enforce multiples of 16

### DIFF
--- a/src/allencell_ml_segmenter/_tests/training/test_patch_size_validator.py
+++ b/src/allencell_ml_segmenter/_tests/training/test_patch_size_validator.py
@@ -23,24 +23,24 @@ def test_validate_invalid(validator: PatchSizeValidator) -> None:
 
 def test_validate_intermediate(validator: PatchSizeValidator) -> None:
     assert validator.validate("1", 0)[0] == QValidator.State.Intermediate
-    assert validator.validate("2", 0)[0] == QValidator.State.Intermediate
-    assert validator.validate("3", 0)[0] == QValidator.State.Intermediate
+    assert validator.validate("4", 0)[0] == QValidator.State.Intermediate
+    assert validator.validate("8", 0)[0] == QValidator.State.Intermediate
     assert validator.validate("22", 0)[0] == QValidator.State.Intermediate
     assert validator.validate("109", 0)[0] == QValidator.State.Intermediate
 
 
 def test_validate_acceptable(validator: PatchSizeValidator) -> None:
-    assert validator.validate("4", 0)[0] == QValidator.State.Acceptable
-    assert validator.validate("8", 0)[0] == QValidator.State.Acceptable
+    assert validator.validate("16", 0)[0] == QValidator.State.Acceptable
+    assert validator.validate("32", 0)[0] == QValidator.State.Acceptable
     assert validator.validate("64", 0)[0] == QValidator.State.Acceptable
-    assert validator.validate("72", 0)[0] == QValidator.State.Acceptable
+    assert validator.validate("80", 0)[0] == QValidator.State.Acceptable
     assert validator.validate("128", 0)[0] == QValidator.State.Acceptable
 
 
 def test_fixup(validator: PatchSizeValidator) -> None:
-    assert validator.fixup("1") == "4"
-    assert validator.fixup("3") == "4"
-    assert validator.fixup("5") == "4"
-    assert validator.fixup("9") == "8"
-    assert validator.fixup("11") == "8"
+    assert validator.fixup("1") == "16"
+    assert validator.fixup("3") == "16"
+    assert validator.fixup("5") == "16"
+    assert validator.fixup("30") == "16"
+    assert validator.fixup("34") == "32"
     assert validator.fixup("131") == "128"

--- a/src/allencell_ml_segmenter/training/patch_size_validator.py
+++ b/src/allencell_ml_segmenter/training/patch_size_validator.py
@@ -2,6 +2,7 @@ import typing
 from qtpy.QtGui import QValidator
 
 
+PATCH_SIZE_MULTIPLE_OF = 16
 # https://doc.qt.io/qtforpython-5/PySide2/QtGui/QValidator.html
 class PatchSizeValidator(QValidator):
     # override
@@ -13,10 +14,10 @@ class PatchSizeValidator(QValidator):
         if a0 is not None and a0.isdecimal():
             as_int: int = int(a0)
             # negative and 0 patch sizes not allowed
-            if as_int < 4:
-                as_int = 4
+            if as_int < PATCH_SIZE_MULTIPLE_OF:
+                as_int = PATCH_SIZE_MULTIPLE_OF
             # round down to the nearest multiple of 4
-            return str(as_int - (as_int % 4))
+            return str(as_int - (as_int % PATCH_SIZE_MULTIPLE_OF))
         else:
             return a0 if a0 is not None else ""
 
@@ -38,7 +39,7 @@ class PatchSizeValidator(QValidator):
                 as_int: int = int(a0)
                 if as_int <= 0:
                     status = QValidator.State.Invalid
-                elif as_int % 4 == 0:
+                elif as_int % PATCH_SIZE_MULTIPLE_OF == 0:
                     status = QValidator.State.Acceptable
             else:
                 status = QValidator.State.Invalid

--- a/src/allencell_ml_segmenter/training/patch_size_validator.py
+++ b/src/allencell_ml_segmenter/training/patch_size_validator.py
@@ -3,6 +3,8 @@ from qtpy.QtGui import QValidator
 
 
 PATCH_SIZE_MULTIPLE_OF = 16
+
+
 # https://doc.qt.io/qtforpython-5/PySide2/QtGui/QValidator.html
 class PatchSizeValidator(QValidator):
     # override

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -31,7 +31,7 @@ from allencell_ml_segmenter.training.training_model import (
     ModelSize,
 )
 from allencell_ml_segmenter.training.patch_size_validator import (
-    PatchSizeValidator,
+    PatchSizeValidator, PATCH_SIZE_MULTIPLE_OF,
 )
 from allencell_ml_segmenter.widgets.label_with_hint_widget import LabelWithHint
 from qtpy.QtGui import QIntValidator
@@ -160,7 +160,7 @@ class TrainingView(View, MainWindow):
             "Patch size to split images into during training. Should encompass the structure of interest and all dimensions should be evenly divisble by 4. If 2D, Z can be left blank."
         )
         patch_size_text_layout.addWidget(patch_size_label)
-        guide_text: QLabel = QLabel("All values must be multiples of 4")
+        guide_text: QLabel = QLabel(f"All values must be multiples of {PATCH_SIZE_MULTIPLE_OF}")
         guide_text.setObjectName("subtext")
         patch_size_text_layout.addWidget(guide_text)
         bottom_grid_layout.addLayout(patch_size_text_layout, 1, 0)

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -31,7 +31,8 @@ from allencell_ml_segmenter.training.training_model import (
     ModelSize,
 )
 from allencell_ml_segmenter.training.patch_size_validator import (
-    PatchSizeValidator, PATCH_SIZE_MULTIPLE_OF,
+    PatchSizeValidator,
+    PATCH_SIZE_MULTIPLE_OF,
 )
 from allencell_ml_segmenter.widgets.label_with_hint_widget import LabelWithHint
 from qtpy.QtGui import QIntValidator
@@ -160,7 +161,9 @@ class TrainingView(View, MainWindow):
             "Patch size to split images into during training. Should encompass the structure of interest and all dimensions should be evenly divisble by 4. If 2D, Z can be left blank."
         )
         patch_size_text_layout.addWidget(patch_size_label)
-        guide_text: QLabel = QLabel(f"All values must be multiples of {PATCH_SIZE_MULTIPLE_OF}")
+        guide_text: QLabel = QLabel(
+            f"All values must be multiples of {PATCH_SIZE_MULTIPLE_OF}"
+        )
         guide_text.setObjectName("subtext")
         patch_size_text_layout.addWidget(guide_text)
         bottom_grid_layout.addLayout(patch_size_text_layout, 1, 0)


### PR DESCRIPTION
## Purpose
Due to the model depth being changed, we need our patch sizes to be multiples of 16 (2^4).

## Changes
Changed our PatchSizeValidator to use a constant PATCH_SIZE_MULTIPLE_OF to enforce values that are a multiple of x.
Set PATCH_SIZE_MULTIPLE_OF to 16.
Changed tests to reflect these changes

## Testing
Ran locally, can confirm it now defaults to multiples of 16

## How to review
src/allencell_ml_segmenter/training/patch_size_validator.py: Contains most of the functional changes, including the new constant and changing the validator to use this new constant when enforcing patch size. We can change PATCH_SIZE_MULTIPLE_OF if we ever need to in the future.
src/allencell_ml_segmenter/training/view.py: Just a change to the label language in the view
src/allencell_ml_segmenter/_tests/training/test_patch_size_validator.py: Fixed tests