### PR TITLE
pin new cyto-dl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "bioio",
     "tifffile>=2023.4.12",
     "watchdog",
-    "cyto-dl>=0.4.3",
+    "cyto-dl>=0.4.4",
     "scikit-image!=0.23.0",
 ]
 


### PR DESCRIPTION
## Purpose
Fixes thao's issue running predictions from models trained from scratch

## Changes
pins new version of cyto-dl that addresses this fix

## Testing
tested locally on windows

## How to review
one liner version pin change