### PR TITLE
put prediction csv in a subdirectory to not confuse cyto-dl

### DIFF
--- a/src/allencell_ml_segmenter/_tests/services/test_prediction_service.py
+++ b/src/allencell_ml_segmenter/_tests/services/test_prediction_service.py
@@ -120,7 +120,8 @@ def test_build_overrides() -> None:
         / "0_exp"
         / "prediction_output_test"
     )
-    prediction_model.set_input_image_path(Path("fake_img_path"))
+    fake_path: Path = Path("fake_img_path")
+    prediction_model.set_input_image_path(fake_path)
     prediction_model.set_image_input_channel_index(3)
 
     # act
@@ -134,6 +135,7 @@ def test_build_overrides() -> None:
     assert overrides["train"] == False
     assert overrides["mode"] == "predict"
     assert overrides["task_name"] == "predict_task_from_app"
+    assert overrides["data.path"] == str(fake_path)
     assert overrides["checkpoint.ckpt_path"] == str(
         Path(__file__).parent.parent
         / "main"

--- a/src/allencell_ml_segmenter/services/prediction_service.py
+++ b/src/allencell_ml_segmenter/services/prediction_service.py
@@ -179,7 +179,7 @@ class PredictionService(Subscriber):
         data_folder: Optional[Path] = self._experiments_model.get_csv_path()
         if data_folder is not None:
             data_folder.mkdir(parents=False, exist_ok=True)
-            csv_path: Path = data_folder / "test_csv.csv"
+            csv_path: Path = data_folder / "prediction_csv" / "test_csv.csv"
             with open(csv_path, "w") as file:
                 writer = csv.writer(file)
                 writer.writerow(["", "raw", "split"])


### PR DESCRIPTION
## Purpose
Fixes https://github.com/AllenCell/allencell-segmenter-ml/issues/570

## Changes
The prediction csv generated is put into a subdirectory- so if that data folder is reused in another experiment, it does not 
confuse cyto-dl

## Testing
Tested on windows

## How to review
One lline change