### PR TITLE
Refactor/move original layer data to layer metadata

### DIFF
--- a/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
+++ b/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
@@ -13,7 +13,7 @@ from allencell_ml_segmenter.main.segmenter_layer import (
 from napari.utils.events import Event as NapariEvent
 import napari
 from typing import List, Dict, Callable, Optional
-from napari.layers import Layer
+from napari.layers import Layer, Labels
 
 
 class FakeNapariEvent:
@@ -137,3 +137,10 @@ class FakeViewer(IViewer):
             return Path(layer.metadata["source_path"])
 
         return None
+
+    # TODO: add these fakes for testing methods that rely on this
+    def add_segmentation_labels(self, masked_data: np.ndarray, name: str, prob_map: np.ndarray) -> None:
+        pass
+
+    def get_all_segmentation_labels(self) -> list[Labels]:
+        pass

--- a/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
+++ b/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
@@ -139,8 +139,15 @@ class FakeViewer(IViewer):
         return None
 
     # TODO: add these fakes for testing methods that rely on this
-    def add_segmentation_labels(self, masked_data: np.ndarray, name: str, prob_map: np.ndarray) -> None:
+    def add_segmentation_labels(
+        self, masked_data: np.ndarray, name: str, prob_map: np.ndarray
+    ) -> None:
         pass
 
     def get_all_segmentation_labels(self) -> list[Labels]:
-        pass
+        return [
+            layer
+            for layer in self.get_all_images()
+            if getattr(layer, "metadata", None)
+            and "prob_map" in layer.metadata
+        ]

--- a/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
+++ b/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
@@ -138,12 +138,6 @@ class FakeViewer(IViewer):
 
         return None
 
-    # TODO: add these fakes for testing methods that rely on this
-    def add_segmentation_labels(
-        self, masked_data: np.ndarray, name: str, prob_map: np.ndarray
-    ) -> None:
-        pass
-
     def get_all_segmentation_labels(self) -> list[Labels]:
         return [
             layer

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -68,11 +68,20 @@ def test_on_threshold_changed_non_prediction(test_image):
         viewer,
         task_executor=SynchroTaskExecutor.global_instance(),
     )
-    # Only the [seg] layers below should produce a threshold layer
+
+    # Only the [seg] layers below should produce a threshold layer since they have prob map metadata
     viewer.add_image(test_image, name="[raw] test_layer 1")
-    viewer.add_image(test_image, name="[seg] test_layer 1")
+    viewer.add_image(
+        test_image,
+        name="[seg] test_layer 1",
+        metadata={"prob_map": test_image},
+    )
     viewer.add_image(test_image, name="[raw] test_layer 2")
-    viewer.add_image(test_image, name="[seg] test_layer 2")
+    viewer.add_image(
+        test_image,
+        name="[seg] test_layer 2",
+        metadata={"prob_map": test_image},
+    )
     viewer.add_image(test_image, name="donotthreshold")
 
     # ACT set a threshold to trigger

--- a/src/allencell_ml_segmenter/main/i_viewer.py
+++ b/src/allencell_ml_segmenter/main/i_viewer.py
@@ -7,7 +7,7 @@ from allencell_ml_segmenter.main.segmenter_layer import (
     LabelsLayer,
 )
 import numpy as np
-from napari.layers import Layer  # type: ignore
+from napari.layers import Layer, Labels  # type: ignore
 from napari.utils.events import Event as NapariEvent  # type: ignore
 
 
@@ -105,3 +105,12 @@ class IViewer(ABC):
     @abstractmethod
     def get_source_path(self, layer: Layer) -> Optional[Path]:
         pass
+
+    @abstractmethod
+    def add_segmentation_labels(self, masked_data: np.ndarray, name: str, prob_map: np.ndarray) -> None:
+        pass
+
+    @abstractmethod
+    def get_all_segmentation_labels(self) -> list[Labels]:
+        pass
+

--- a/src/allencell_ml_segmenter/main/i_viewer.py
+++ b/src/allencell_ml_segmenter/main/i_viewer.py
@@ -111,6 +111,6 @@ class IViewer(ABC):
         pass
 
     @abstractmethod
-    def get_all_segmentation_labels(self) -> list[Labels]:
+    def get_all_segmentation_labels(self) -> list[LabelsLayer]:
         pass
 

--- a/src/allencell_ml_segmenter/main/i_viewer.py
+++ b/src/allencell_ml_segmenter/main/i_viewer.py
@@ -107,11 +107,5 @@ class IViewer(ABC):
         pass
 
     @abstractmethod
-    def add_segmentation_labels(
-        self, masked_data: np.ndarray, name: str, prob_map: np.ndarray
-    ) -> None:
-        pass
-
-    @abstractmethod
     def get_all_segmentation_labels(self) -> list[LabelsLayer]:
         pass

--- a/src/allencell_ml_segmenter/main/i_viewer.py
+++ b/src/allencell_ml_segmenter/main/i_viewer.py
@@ -107,10 +107,11 @@ class IViewer(ABC):
         pass
 
     @abstractmethod
-    def add_segmentation_labels(self, masked_data: np.ndarray, name: str, prob_map: np.ndarray) -> None:
+    def add_segmentation_labels(
+        self, masked_data: np.ndarray, name: str, prob_map: np.ndarray
+    ) -> None:
         pass
 
     @abstractmethod
     def get_all_segmentation_labels(self) -> list[LabelsLayer]:
         pass
-

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -192,3 +192,22 @@ class Viewer(IViewer):
         if layer.metadata is not None and "source_path" in layer.metadata:
             return Path(layer.metadata["source_path"])
         return None
+
+    def add_segmentation_labels(self, masked_data: np.ndarray, name: str, prob_map: np.ndarray) -> None:
+        """
+        Add a segmentation labels layer and save probability mapping in the layer metadata.
+        """
+        self.add_labels(
+            masked_data,
+            name=name,
+            metadata={
+                "prob_map": prob_map
+            },
+        )
+
+    def get_all_segmentation_labels(self) -> list[Labels]:
+        """
+        Get all segmentation labels layers that currently exist in the viewer.
+        """
+        return [layer for layer in self.get_layers() if "prob_map" in layer.metadata]
+

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -193,21 +193,24 @@ class Viewer(IViewer):
             return Path(layer.metadata["source_path"])
         return None
 
-    def add_segmentation_labels(self, masked_data: np.ndarray, name: str, prob_map: np.ndarray) -> None:
+    def add_segmentation_labels(
+        self, masked_data: np.ndarray, name: str, prob_map: np.ndarray
+    ) -> None:
         """
         Add a segmentation labels layer and save probability mapping in the layer metadata.
         """
         self.add_labels(
             masked_data,
             name=name,
-            metadata={
-                "prob_map": prob_map
-            },
+            metadata={"prob_map": prob_map},
         )
 
     def get_all_segmentation_labels(self) -> list[LabelsLayer]:
         """
         Get all segmentation labels layers that currently exist in the viewer.
         """
-        return [layer for layer in self.get_layers() if "prob_map" in layer.metadata]
-
+        return [
+            layer
+            for layer in self.get_layers()
+            if "prob_map" in layer.metadata
+        ]

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -205,7 +205,7 @@ class Viewer(IViewer):
             },
         )
 
-    def get_all_segmentation_labels(self) -> list[Labels]:
+    def get_all_segmentation_labels(self) -> list[LabelsLayer]:
         """
         Get all segmentation labels layers that currently exist in the viewer.
         """

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -193,18 +193,6 @@ class Viewer(IViewer):
             return Path(layer.metadata["source_path"])
         return None
 
-    def add_segmentation_labels(
-        self, masked_data: np.ndarray, name: str, prob_map: np.ndarray
-    ) -> None:
-        """
-        Add a segmentation labels layer and save probability mapping in the layer metadata.
-        """
-        self.add_labels(
-            masked_data,
-            name=name,
-            metadata={"prob_map": prob_map},
-        )
-
     def get_all_segmentation_labels(self) -> list[LabelsLayer]:
         """
         Get all segmentation labels layers that currently exist in the viewer.

--- a/src/allencell_ml_segmenter/prediction/view.py
+++ b/src/allencell_ml_segmenter/prediction/view.py
@@ -171,8 +171,6 @@ class PredictionView(View, MainWindow):
                 raw_img.stem: {"raw": raw_img} for raw_img in raw_imgs
             }
 
-            # stem -> seg: path, raw: path
-
             if segmentations:
                 for seg in segmentations:
                     # ignore files in the folder that aren't from most recent predictions

--- a/src/allencell_ml_segmenter/prediction/view.py
+++ b/src/allencell_ml_segmenter/prediction/view.py
@@ -170,6 +170,9 @@ class PredictionView(View, MainWindow):
             stem_to_data: dict[str, dict[str, Path]] = {
                 raw_img.stem: {"raw": raw_img} for raw_img in raw_imgs
             }
+
+            # stem -> seg: path, raw: path
+
             if segmentations:
                 for seg in segmentations:
                     # ignore files in the folder that aren't from most recent predictions

--- a/src/allencell_ml_segmenter/thresholding/thresholding_model.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_model.py
@@ -26,9 +26,6 @@ class ThresholdingModel(Publisher):
         self._thresholding_value_selected: int = THRESHOLD_DEFAULT
         self._is_autothresholding_enabled: bool = False
         self._autothresholding_method: str = AVAILABLE_AUTOTHRESHOLD_METHODS[0]
-        self._original_layers_in_viewer: Optional[
-            OrderedDict[str, np.ndarray]
-        ] = None  # Orderedict of layers when thresholding starts, in original order.
 
     def set_thresholding_value(self, value: int) -> None:
         """
@@ -84,32 +81,3 @@ class ThresholdingModel(Publisher):
 
     def dispatch_save_thresholded_images(self) -> None:
         self.dispatch(Event.ACTION_SAVE_THRESHOLDING_IMAGES)
-
-    def set_original_layers(self, layer_list: list[Layer]) -> None:
-        ordered_layers: OrderedDict[str, np.ndarray] = OrderedDict()
-        for layer in layer_list:
-            if layer.metadata is not None and "prob_map" in layer.metadata:
-                ordered_layers[layer.name] = layer.metadata["prob_map"]
-            else:
-                ordered_layers[layer.name] = layer.data
-        self._original_layers_in_viewer = ordered_layers
-
-    def get_original_layers(self) -> Optional[OrderedDict[str, np.ndarray]]:
-        return self._original_layers_in_viewer
-
-    def get_layers_to_threshold(
-        self, only_seg_layers: bool
-    ) -> OrderedDict[str, np.ndarray]:
-        if self._original_layers_in_viewer is None:
-            raise ValueError(
-                "Check original layers in model for None before calling get_layers_to_threshold"
-            )
-
-        if only_seg_layers:
-            return OrderedDict(
-                (key, value)
-                for key, value in self._original_layers_in_viewer.items()
-                if key.startswith("[seg]")
-            )
-
-        return self._original_layers_in_viewer

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -110,8 +110,9 @@ class ThresholdingService(Subscriber):
                 threshold_output: np.ndarray,
             ) -> None:
                 self._viewer.insert_threshold(
-                    layer_instance,
+                    layer_instance.name,
                     threshold_output,
+                    True,
                 )
 
             self._task_executor.exec(

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -72,26 +72,6 @@ class ThresholdingService(Subscriber):
         segmentation_labels: list[LabelsLayer] = (
             self._viewer.get_all_segmentation_labels()
         )
-        # # if we havent thresholded yet, keep track of original layers.
-        # # need to check this on first threshold change, since user can add images
-        # # between finishing prediction and starting thresholding
-        # # if they are using images from a directory.
-        # original_layers: Optional[OrderedDict[str, np.ndarray]] = (
-        #     self._thresholding_model.get_original_layers()
-        # )
-        # if original_layers is None:
-        #     self._thresholding_model.set_original_layers(
-        #         self._viewer.get_layers()
-        #     )
-        #
-        # # Get layers to threshold.
-        # # if there are segmentations displayed in the viewer, only threshold those images.
-        # layers_to_threshold: OrderedDict[str, np.ndarray] = (
-        #     self._thresholding_model.get_layers_to_threshold(
-        #         self._main_model.are_predictions_in_viewer()
-        #     )
-        # )
-        #
 
         # determine thresholding function to use
         if self._thresholding_model.is_autothresholding_enabled():

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -69,7 +69,9 @@ class ThresholdingService(Subscriber):
         show_info("Thresholding failed: " + str(error))
 
     def _on_threshold_changed(self, _: Event) -> None:
-        segmentation_labels: list[LabelsLayer] = self._viewer.get_all_segmentation_labels()
+        segmentation_labels: list[LabelsLayer] = (
+            self._viewer.get_all_segmentation_labels()
+        )
         # # if we havent thresholded yet, keep track of original layers.
         # # need to check this on first threshold change, since user can add images
         # # between finishing prediction and starting thresholding
@@ -103,9 +105,18 @@ class ThresholdingService(Subscriber):
             def thresholding_task() -> np.ndarray:
                 # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin
                 # so we are only supporting thresholding images that are from the plugin itself.
+                if (
+                    not isinstance(layer.metadata, dict)
+                    or "prob_map" not in layer.metadata
+                ):
+                    raise ValueError(
+                        "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
+                    )
+
                 return thresh_function(layer.metadata["prob_map"])
 
             layer_instance: LabelsLayer = layer
+
             def on_return(
                 threshold_output: np.ndarray,
             ) -> None:

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -158,28 +158,3 @@ class ThresholdingService(Subscriber):
             self._thresholding_model.get_thresholding_value()
         )
         return (image > threshold_value).astype(int)
-
-    def _update_original_layers(self, _: Event) -> None:
-        current_layers: list[Layer] = (
-            self._viewer.get_layers()
-        )  # all layers in viewer
-
-        # get layers that were added since last thresholding
-        original_layers: Optional[OrderedDict[str, np.ndarray]] = (
-            self._thresholding_model.get_original_layers()
-        )
-        new_layers_added: list[Layer] = current_layers
-        if original_layers is not None:
-            new_layers_added = [
-                layer
-                for layer in current_layers
-                if layer.name not in original_layers
-            ]
-
-        # refresh layers only if the new layers are not threshold layers (we dont want to track this in original layers state)
-        for new_layer in new_layers_added:
-            if not new_layer.name.startswith("[threshold]"):
-                self._thresholding_model.set_original_layers(
-                    self._viewer.get_layers()
-                )
-                return

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -103,7 +103,7 @@ class ThresholdingService(Subscriber):
                 self._viewer.insert_threshold(
                     layer_instance.name,
                     threshold_output,
-                    True,
+                    self._main_model.are_predictions_in_viewer(),
                 )
 
             self._task_executor.exec(

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Callable, Optional
 from bioio import BioImage
 from bioio.writers import OmeTiffWriter
-from napari.layers import Layer  # type: ignore
+from napari.layers import Layer, Labels  # type: ignore
 import numpy as np
 from napari.utils.notifications import show_info  # type: ignore
 
@@ -12,6 +12,7 @@ from allencell_ml_segmenter.core.file_input_model import FileInputModel
 from allencell_ml_segmenter.core.subscriber import Subscriber
 from allencell_ml_segmenter.main.experiments_model import ExperimentsModel
 from allencell_ml_segmenter.main.main_model import MainModel
+from allencell_ml_segmenter.main.segmenter_layer import LabelsLayer
 from allencell_ml_segmenter.thresholding.thresholding_model import (
     ThresholdingModel,
 )
@@ -72,25 +73,27 @@ class ThresholdingService(Subscriber):
         show_info("Thresholding failed: " + str(error))
 
     def _on_threshold_changed(self, _: Event) -> None:
-        # if we havent thresholded yet, keep track of original layers.
-        # need to check this on first threshold change, since user can add images
-        # between finishing prediction and starting thresholding
-        # if they are using images from a directory.
-        original_layers: Optional[OrderedDict[str, np.ndarray]] = (
-            self._thresholding_model.get_original_layers()
-        )
-        if original_layers is None:
-            self._thresholding_model.set_original_layers(
-                self._viewer.get_layers()
-            )
-
-        # Get layers to threshold.
-        # if there are segmentations displayed in the viewer, only threshold those images.
-        layers_to_threshold: OrderedDict[str, np.ndarray] = (
-            self._thresholding_model.get_layers_to_threshold(
-                self._main_model.are_predictions_in_viewer()
-            )
-        )
+        segmentation_labels: list[LabelsLayer] = self._viewer.get_all_segmentation_labels()
+        # # if we havent thresholded yet, keep track of original layers.
+        # # need to check this on first threshold change, since user can add images
+        # # between finishing prediction and starting thresholding
+        # # if they are using images from a directory.
+        # original_layers: Optional[OrderedDict[str, np.ndarray]] = (
+        #     self._thresholding_model.get_original_layers()
+        # )
+        # if original_layers is None:
+        #     self._thresholding_model.set_original_layers(
+        #         self._viewer.get_layers()
+        #     )
+        #
+        # # Get layers to threshold.
+        # # if there are segmentations displayed in the viewer, only threshold those images.
+        # layers_to_threshold: OrderedDict[str, np.ndarray] = (
+        #     self._thresholding_model.get_layers_to_threshold(
+        #         self._main_model.are_predictions_in_viewer()
+        #     )
+        # )
+        #
 
         # determine thresholding function to use
         if self._thresholding_model.is_autothresholding_enabled():
@@ -99,19 +102,19 @@ class ThresholdingService(Subscriber):
             )
         else:
             thresh_function = self._threshold_image
-        for layer_name, image in layers_to_threshold.items():
+        for layer in segmentation_labels:
             # Creating helper functions for mypy strict typing
             def thresholding_task() -> np.ndarray:
-                return thresh_function(image)
+                # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin
+                return thresh_function(layer.metadata["prob_map"])
 
+            layer_instance: LabelsLayer = layer
             def on_return(
-                thresholded_image: np.ndarray,
-                layer_name_instance: str = layer_name,
+                threshold_output: np.ndarray,
             ) -> None:
                 self._viewer.insert_threshold(
-                    layer_name_instance,
-                    thresholded_image,
-                    self._main_model.are_predictions_in_viewer(),
+                    layer_instance,
+                    threshold_output,
                 )
 
             self._task_executor.exec(

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -102,6 +102,7 @@ class ThresholdingService(Subscriber):
             # Creating helper functions for mypy strict typing
             def thresholding_task() -> np.ndarray:
                 # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin
+                # so we are only supporting thresholding images that are from the plugin itself.
                 return thresh_function(layer.metadata["prob_map"])
 
             layer_instance: LabelsLayer = layer

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -65,10 +65,6 @@ class ThresholdingService(Subscriber):
             self._save_thresholded_images,
         )
 
-        self._viewer.subscribe_layers_change_event(
-            function=self._update_original_layers
-        )
-
     def _handle_thresholding_error(self, error: Exception) -> None:
         show_info("Thresholding failed: " + str(error))
 


### PR DESCRIPTION
## Purpose
- This is a refactor of the thresholding code- enforces that users only threshold images that are generated in the plugin, rather than allowing thresholding of any image dragged into viewer.
- how it works: when segmentations are generated in the prediction part of the plugin, they are saved with the napari viewer metadata `prob_map` which is the original probability mapping before any thresholding is applied.
- Thresholding looks for all layers with a `prob_map` key in its metadata- which indicates it is a segmentation generated from our plugin
- thresholding is performed with `prob_map` as the input.
- This will need some UI changes to work completely, which will come in a follow up PR (i will stop using the FileInputWidget, which allows the user to select any image dropped in napari, and instead only allow selection of images generated in prediction)

## Changes
- Main change is removing the `original_layers_in_viewer` field from the thresholding model. We instead track the original probability mappings through the layer metadata itself.
- Includes changes in other parts of the plugin that used to depend on `original_layers_in_viewer` field. Uses the napari viewer metadata instead now.

## Testing
Tested on windows

## How to review
- start with `src/allencell_ml_segmenter/thresholding/thresholding_model.py` which contains the changes to get rid of the `original_layers_in_viewer` field.
- review `src/allencell_ml_segmenter/thresholding/thresholding_service.py` which contains most of the changes that are affected by changing the way we store prediction outputs as napari viewer metadata rather than as the `original_layers_in_viewer` field.
- review other files that have changed as a result of this model change
