### PR TITLE
Refactor/create inputwidget for prediction outputs

### DIFF
--- a/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
+++ b/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
@@ -118,7 +118,7 @@ class FakeViewer(IViewer):
             if layer.name.startswith("[seg]")
         ]
 
-    def insert_threshold(
+    def insert_binary_map_into_layer(
         self, layer: ImageLayer, img: np.ndarray, seg_layers: bool = False
     ) -> None:
         self.threshold_inserted[f"[threshold] {layer.name}"] = img
@@ -138,7 +138,7 @@ class FakeViewer(IViewer):
 
         return None
 
-    def get_all_segmentation_labels(self) -> list[Layer]:
+    def get_all_layers_containing_prob_map(self) -> list[Layer]:
         return [
             layer
             for layer in self.get_all_images()

--- a/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
+++ b/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
@@ -119,9 +119,9 @@ class FakeViewer(IViewer):
         ]
 
     def insert_threshold(
-        self, layer_name: str, img: np.ndarray, seg_layers: bool = False
+        self, layer: ImageLayer, img: np.ndarray, seg_layers: bool = False
     ) -> None:
-        self.threshold_inserted[f"[threshold] {layer_name}"] = img
+        self.threshold_inserted[f"[threshold] {layer.name}"] = img
 
     def get_layers_nonthreshold(self) -> list[Layer]:
         return [
@@ -138,7 +138,7 @@ class FakeViewer(IViewer):
 
         return None
 
-    def get_all_segmentation_labels(self) -> list[Labels]:
+    def get_all_segmentation_labels(self) -> list[Layer]:
         return [
             layer
             for layer in self.get_all_images()

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -84,7 +84,6 @@ def test_on_threshold_changed_non_prediction(test_image):
         metadata={"prob_map": test_image},
     )
     viewer.add_image(test_image, name="donotthreshold")
-    file_input_model.set_selected_idx([0, 1])
 
     # ACT set a threshold to trigger
     thresholding_model.set_thresholding_value(50)

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -60,10 +60,11 @@ def test_on_threshold_changed_non_prediction(test_image):
     viewer: FakeViewer = FakeViewer()
     main_model: MainModel = MainModel()
     main_model.set_predictions_in_viewer(True)
+    file_input_model: FileInputModel = FileInputModel()
     thresholding_service: ThresholdingService = ThresholdingService(
         thresholding_model,
         FakeExperimentsModel(),
-        FileInputModel(),
+        file_input_model,
         main_model,
         viewer,
         task_executor=SynchroTaskExecutor.global_instance(),
@@ -83,6 +84,7 @@ def test_on_threshold_changed_non_prediction(test_image):
         metadata={"prob_map": test_image},
     )
     viewer.add_image(test_image, name="donotthreshold")
+    file_input_model.set_selected_idx([0, 1])
 
     # ACT set a threshold to trigger
     thresholding_model.set_thresholding_value(50)

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -84,6 +84,7 @@ def test_on_threshold_changed_non_prediction(test_image):
         metadata={"prob_map": test_image},
     )
     viewer.add_image(test_image, name="donotthreshold")
+    file_input_model.set_selected_idx([0, 1])
 
     # ACT set a threshold to trigger
     thresholding_model.set_thresholding_value(50)

--- a/src/allencell_ml_segmenter/core/file_input_model.py
+++ b/src/allencell_ml_segmenter/core/file_input_model.py
@@ -24,6 +24,7 @@ class FileInputModel(Publisher):
         self._input_mode: Optional[InputMode] = None
         self._selected_paths: Optional[list[Path]] = None
         self._max_channels: Optional[int] = None
+        self._selected_idx: Optional[list[int]] = None
 
     def get_output_seg_directory(self) -> Optional[Path]:
         """
@@ -92,3 +93,9 @@ class FileInputModel(Publisher):
             if selected_paths is not None:
                 return selected_paths
         return []
+
+    def set_selected_idx(self, selected_idx: list[int]) -> None:
+        self._selected_idx = selected_idx
+
+    def get_selected_idx(self) -> Optional[list[int]]:
+        return self._selected_idx

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -30,7 +30,9 @@ class PredictionResultListWidget(FileInputWidget):
     def _update_layer_list(self, event: Optional[NapariEvent] = None) -> None:
         previous_selections: list[int] = self._image_list.get_checked_rows()
         self._image_list.clear()
-        self._prediction_layers = self._viewer.get_all_segmentation_labels()
+        self._prediction_layers = (
+            self._viewer.get_all_layers_containing_prob_map()
+        )
         for idx, prediction_output_layer in enumerate(self._prediction_layers):
             self._image_list.add_item(
                 prediction_output_layer.name,

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -1,0 +1,45 @@
+from allencell_ml_segmenter.core.file_input_model import (
+    InputMode,
+    FileInputModel,
+)
+from allencell_ml_segmenter.core.file_input_widget import FileInputWidget
+from allencell_ml_segmenter.main.i_viewer import IViewer
+from allencell_ml_segmenter.main.segmenter_layer import LabelsLayer
+from qtpy.QtCore import Qt
+
+from allencell_ml_segmenter.prediction.service import ModelFileService
+
+
+class PredictionResultListWidget(FileInputWidget):
+    """
+    Widget containing a list of prediction results that are selectable for thresholding
+    """
+
+    def __init__(
+        self, model: FileInputModel, viewer: IViewer, service: ModelFileService
+    ):
+        super().__init__(
+            model, viewer, service, include_channel_selection=False
+        )
+        self._prediction_layers: list[LabelsLayer] = (
+            self._viewer.get_all_segmentation_labels()
+        )
+
+    def _update_layer_list(self) -> None:
+        self._image_list.clear()
+        self._reset_channel_combobox()
+        self._prediction_layers = self._viewer.get_all_segmentation_labels()
+        for prediction_output_layer in self._prediction_layers:
+            self._image_list.add_item(
+                prediction_output_layer.name,
+            )
+
+    def process_checked_signal(self, row: int, state: Qt.CheckState) -> None:
+        if self._model.get_input_mode() == InputMode.FROM_NAPARI_LAYERS:
+            selected_indices: list[int] = self._image_list.get_checked_rows()
+            if state == Qt.CheckState.Checked:
+                # paths of images to be segmented, which will not be opened again because already in memory
+                # but satisfies file_input_model state which determines if we have anything selected
+                self._model.set_selected_paths(
+                    [x.path for x in self._prediction_layers]
+                )

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -21,9 +21,7 @@ class PredictionResultListWidget(FileInputWidget):
         super().__init__(
             model, viewer, service, include_channel_selection=False
         )
-        self._prediction_layers: list[LabelsLayer] = (
-            self._viewer.get_all_segmentation_labels()
-        )
+        self._prediction_layers: list[LabelsLayer] = []
 
     def _update_layer_list(self) -> None:
         self._image_list.clear()

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -36,10 +36,4 @@ class PredictionResultListWidget(FileInputWidget):
 
     def process_checked_signal(self, row: int, state: Qt.CheckState) -> None:
         if self._model.get_input_mode() == InputMode.FROM_NAPARI_LAYERS:
-            selected_indices: list[int] = self._image_list.get_checked_rows()
-            if state == Qt.CheckState.Checked:
-                # paths of images to be segmented, which will not be opened again because already in memory
-                # but satisfies file_input_model state which determines if we have anything selected
-                self._model.set_selected_paths(
-                    [x.path for x in self._prediction_layers]
-                )
+            self._model.set_selected_idx(self._image_list.get_checked_rows())

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from allencell_ml_segmenter.core.file_input_model import (
     InputMode,
     FileInputModel,
@@ -8,6 +10,8 @@ from allencell_ml_segmenter.main.segmenter_layer import LabelsLayer
 from qtpy.QtCore import Qt
 
 from allencell_ml_segmenter.prediction.service import ModelFileService
+
+from napari.utils.events import Event as NapariEvent  # type: ignore
 
 
 class PredictionResultListWidget(FileInputWidget):
@@ -23,7 +27,7 @@ class PredictionResultListWidget(FileInputWidget):
         )
         self._prediction_layers: list[LabelsLayer] = []
 
-    def _update_layer_list(self) -> None:
+    def _update_layer_list(self, event: NapariEvent | None = None) -> None:
         previous_selections: list[int] = self._image_list.get_checked_rows()
         self._image_list.clear()
         self._prediction_layers = self._viewer.get_all_segmentation_labels()

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -27,7 +27,6 @@ class PredictionResultListWidget(FileInputWidget):
 
     def _update_layer_list(self) -> None:
         self._image_list.clear()
-        self._reset_channel_combobox()
         self._prediction_layers = self._viewer.get_all_segmentation_labels()
         for prediction_output_layer in self._prediction_layers:
             self._image_list.add_item(

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -30,9 +30,8 @@ class PredictionResultListWidget(FileInputWidget):
         for idx, prediction_output_layer in enumerate(self._prediction_layers):
             self._image_list.add_item(
                 prediction_output_layer.name,
-                set_checked=idx in previous_selections
+                set_checked=idx in previous_selections,
             )
-
 
     def _process_checked_signal(self, row: int, state: Qt.CheckState) -> None:
         if self._model.get_input_mode() == InputMode.FROM_NAPARI_LAYERS:

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from allencell_ml_segmenter.core.file_input_model import (
     InputMode,
@@ -27,7 +27,7 @@ class PredictionResultListWidget(FileInputWidget):
         )
         self._prediction_layers: list[LabelsLayer] = []
 
-    def _update_layer_list(self, event: NapariEvent | None = None) -> None:
+    def _update_layer_list(self, event: Optional[NapariEvent] = None) -> None:
         previous_selections: list[int] = self._image_list.get_checked_rows()
         self._image_list.clear()
         self._prediction_layers = self._viewer.get_all_segmentation_labels()

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -34,6 +34,6 @@ class PredictionResultListWidget(FileInputWidget):
             )
 
 
-    def process_checked_signal(self, row: int, state: Qt.CheckState) -> None:
+    def _process_checked_signal(self, row: int, state: Qt.CheckState) -> None:
         if self._model.get_input_mode() == InputMode.FROM_NAPARI_LAYERS:
             self._model.set_selected_idx(self._image_list.get_checked_rows())

--- a/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
+++ b/src/allencell_ml_segmenter/core/prediction_result_input_widget.py
@@ -24,12 +24,15 @@ class PredictionResultListWidget(FileInputWidget):
         self._prediction_layers: list[LabelsLayer] = []
 
     def _update_layer_list(self) -> None:
+        previous_selections: list[int] = self._image_list.get_checked_rows()
         self._image_list.clear()
         self._prediction_layers = self._viewer.get_all_segmentation_labels()
-        for prediction_output_layer in self._prediction_layers:
+        for idx, prediction_output_layer in enumerate(self._prediction_layers):
             self._image_list.add_item(
                 prediction_output_layer.name,
+                set_checked=idx in previous_selections
             )
+
 
     def process_checked_signal(self, row: int, state: Qt.CheckState) -> None:
         if self._model.get_input_mode() == InputMode.FROM_NAPARI_LAYERS:

--- a/src/allencell_ml_segmenter/main/i_viewer.py
+++ b/src/allencell_ml_segmenter/main/i_viewer.py
@@ -83,7 +83,7 @@ class IViewer(ABC):
         pass
 
     @abstractmethod
-    def insert_threshold(
+    def insert_binary_map_into_layer(
         self, layer_name: str, img: np.ndarray, seg_layers: bool = False
     ) -> None:
         """
@@ -107,5 +107,5 @@ class IViewer(ABC):
         pass
 
     @abstractmethod
-    def get_all_segmentation_labels(self) -> list[Layer]:
+    def get_all_layers_containing_prob_map(self) -> list[Layer]:
         pass

--- a/src/allencell_ml_segmenter/main/i_viewer.py
+++ b/src/allencell_ml_segmenter/main/i_viewer.py
@@ -107,5 +107,5 @@ class IViewer(ABC):
         pass
 
     @abstractmethod
-    def get_all_segmentation_labels(self) -> list[LabelsLayer]:
+    def get_all_segmentation_labels(self) -> list[Layer]:
         pass

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -141,7 +141,7 @@ class Viewer(IViewer):
             if layer.name.startswith("[seg]")
         ]
 
-    def insert_threshold(
+    def insert_binary_map_into_layer(
         self,
         layer: Layer,
         image: np.ndarray,
@@ -176,7 +176,7 @@ class Viewer(IViewer):
             return Path(layer.metadata["source_path"])
         return None
 
-    def get_all_segmentation_labels(self) -> list[Layer]:
+    def get_all_layers_containing_prob_map(self) -> list[Layer]:
         """
         Get all segmentation labels layers that currently exist in the viewer.
         """

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -158,7 +158,7 @@ class Viewer(IViewer):
         :param remove_seg_layers: boolean indicating if the layer that is being thresholded is a segmentation layer, and should be removed from the layer once it is updated with the threshold.
         """
         # if threshold has not been previously applied, update name
-        if "threshold_applied" in layer.metadata and not layer.metadata["threshold_applied"]:
+        if "threshold_applied" not in layer.metadata:
             layer.name = f"[threshold] {layer.name}"
         layer.data = image
         layer.metadata["threshold_applied"] = True

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -158,7 +158,7 @@ class Viewer(IViewer):
         :param remove_seg_layers: boolean indicating if the layer that is being thresholded is a segmentation layer, and should be removed from the layer once it is updated with the threshold.
         """
         # if threshold has not been previously applied, update name
-        if not layer.metadata["threshold_applied"]:
+        if "threshold_applied" in layer.metadata and not layer.metadata["threshold_applied"]:
             layer.name = f"[threshold] {layer.name}"
         layer.data = image
         layer.metadata["threshold_applied"] = True

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -143,7 +143,7 @@ class Viewer(IViewer):
 
     def insert_threshold(
         self,
-        layer_name: str,
+        layer: Layer,
         image: np.ndarray,
         remove_seg_layers: bool = False,
     ) -> None:
@@ -153,33 +153,13 @@ class Viewer(IViewer):
         If the layer does not exist, it will be added to the viewer in the correct place (on top of the original segmentation image:
         index_of_segmentation + 1 in the LayerList)
 
-        :param layer_name: name of layer to insert. Will replace if one exists, will create one in a new position if needed.
+        :param layer: layer to replace.
         :param image: image to insert
         :param remove_seg_layers: boolean indicating if the layer that is being thresholded is a segmentation layer, and should be removed from the layer once it is updated with the threshold.
         """
-        layer_to_insert = self._get_layer_by_name(f"[threshold] {layer_name}")
-        if layer_to_insert is None:
-            # No thresholding exists, so we add it to the correct place in the viewer
-            layerlist = self.viewer.layers
-
-            # check if the original segementation layer is currently in the viewer, if so, remove later after
-            # thresholding is applied
-            seg_layer_og: Optional[Layer] = None
-            if remove_seg_layers:
-                seg_layer_og = self._get_layer_by_name(layer_name)
-
-            # figure out where to insert the new thresholded layer (on top of the original segmentation image)
-            layerlist_pos = layerlist.index(layer_name)
-            labels_created = Labels(image, name=f"[threshold] {layer_name}")
-            layerlist.insert(layerlist_pos + 1, labels_created)
-
-            # remove the original segmentation layer if it exists
-            if seg_layer_og:
-                layerlist.remove(seg_layer_og)
-        else:
-            # Thresholding already exists so just update the existing one in the viewer.
-            layer_to_insert.data = image
-            layer_to_insert.refresh()
+        layer.name = f"[threshold] {layer.name}"
+        layer.data = image
+        layer.refresh()
 
     def get_source_path(self, layer: Layer) -> Optional[Path]:
         """
@@ -193,7 +173,7 @@ class Viewer(IViewer):
             return Path(layer.metadata["source_path"])
         return None
 
-    def get_all_segmentation_labels(self) -> list[LabelsLayer]:
+    def get_all_segmentation_labels(self) -> list[Layer]:
         """
         Get all segmentation labels layers that currently exist in the viewer.
         """

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -157,8 +157,11 @@ class Viewer(IViewer):
         :param image: image to insert
         :param remove_seg_layers: boolean indicating if the layer that is being thresholded is a segmentation layer, and should be removed from the layer once it is updated with the threshold.
         """
-        layer.name = f"[threshold] {layer.name}"
+        # if threshold has not been previously applied, update name
+        if not layer.metadata["threshold_applied"]:
+            layer.name = f"[threshold] {layer.name}"
         layer.data = image
+        layer.metadata["threshold_applied"] = True
         layer.refresh()
 
     def get_source_path(self, layer: Layer) -> Optional[Path]:

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -148,9 +148,9 @@ class Viewer(IViewer):
         remove_seg_layers: bool = False,
     ) -> None:
         """
-        Insert a thresholded image into the viewer.
-        If a layer for this thresholded image already exists, the new image will replace the old one and refresh the viewer.
-        If the layer does not exist, it will be added to the viewer in the correct place (on top of the original segmentation image:
+        Insert a binary mpa image into the viewer.
+        If a layer for this binary map image already exists, the new image will replace the old one and refresh the viewer.
+        If the layer does not exist, it will be added to the viewer in the correct place (on top of the original raw image:
         index_of_segmentation + 1 in the LayerList)
 
         :param layer: layer to replace.

--- a/src/allencell_ml_segmenter/prediction/view.py
+++ b/src/allencell_ml_segmenter/prediction/view.py
@@ -202,8 +202,8 @@ class PredictionView(View, MainWindow):
                             metadata={
                                 "source_path": data["seg"],
                                 "prob_map": self._img_data_extractor.extract_image_data(
-                                    data["seg"], dims=True
-                                ),
+                                    data["seg"]
+                                ).np_data,
                             },
                         )
 

--- a/src/allencell_ml_segmenter/prediction/view.py
+++ b/src/allencell_ml_segmenter/prediction/view.py
@@ -202,8 +202,8 @@ class PredictionView(View, MainWindow):
                             metadata={
                                 "source_path": data["seg"],
                                 "prob_map": self._img_data_extractor.extract_image_data(
-                                    data["seg"]
-                                ).np_data,
+                                    data["seg"], dims=True
+                                ),
                             },
                         )
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -99,9 +99,10 @@ class ThresholdingService(Subscriber):
 
             def on_return(
                 threshold_output: np.ndarray,
+                layer_to_change: LabelsLayer = layer_instance,
             ) -> None:
                 self._viewer.insert_threshold(
-                    layer_instance,
+                    layer_to_change,
                     threshold_output,
                     self._main_model.are_predictions_in_viewer(),
                 )

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -81,7 +81,10 @@ class ThresholdingService(Subscriber):
         else:
             thresh_function = self._threshold_image
         for idx, layer in enumerate(segmentation_labels):
-            if idx in self._file_input_model.get_selected_idx():
+            selected_idx: list[int] | None = (
+                self._file_input_model.get_selected_idx()
+            )
+            if selected_idx is not None and idx in selected_idx:
                 # Creating helper functions for mypy strict typing
                 def thresholding_task(
                     layer_instance: Layer = layer,

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -69,8 +69,8 @@ class ThresholdingService(Subscriber):
         show_info("Thresholding failed: " + str(error))
 
     def _on_threshold_changed(self, _: Event) -> None:
-        segmentation_labels: list[Layer] = (
-            self._viewer.get_all_segmentation_labels()
+        layers_containing_prob_map: list[Layer] = (
+            self._viewer.get_all_layers_containing_prob_map()
         )
 
         # determine thresholding function to use
@@ -80,11 +80,15 @@ class ThresholdingService(Subscriber):
             )
         else:
             thresh_function = self._threshold_image
-        for idx, layer in enumerate(segmentation_labels):
-            selected_idx: Optional[list[int]] = (
-                self._file_input_model.get_selected_idx()
-            )
-            if selected_idx is not None and idx in selected_idx:
+
+        selected_idx: Optional[list[int]] = (
+            self._file_input_model.get_selected_idx()
+        )
+
+        if selected_idx is not None:
+            for idx in selected_idx:
+                layer: Layer = layers_containing_prob_map[idx]
+
                 # Creating helper functions for mypy strict typing
                 def thresholding_task(
                     layer_instance: Layer = layer,
@@ -98,16 +102,16 @@ class ThresholdingService(Subscriber):
                         raise ValueError(
                             "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
                         )
-
+                    # This thresholding task returns a binary map
                     return thresh_function(layer_instance.metadata["prob_map"])
 
                 def on_return(
-                    threshold_output: np.ndarray,
+                    resulting_binary_map: np.ndarray,
                     layer_instance: Layer = layer,
                 ) -> None:
-                    self._viewer.insert_threshold(
+                    self._viewer.insert_binary_map_into_layer(
                         layer_instance,
-                        threshold_output,
+                        resulting_binary_map,
                         self._main_model.are_predictions_in_viewer(),
                     )
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -69,7 +69,7 @@ class ThresholdingService(Subscriber):
         show_info("Thresholding failed: " + str(error))
 
     def _on_threshold_changed(self, _: Event) -> None:
-        segmentation_labels: list[LabelsLayer] = (
+        segmentation_labels: list[Layer] = (
             self._viewer.get_all_segmentation_labels()
         )
 
@@ -93,7 +93,7 @@ class ThresholdingService(Subscriber):
                         "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
                     )
 
-                return thresh_function(layer.metadata["prob_map"].np_data)
+                return thresh_function(layer.metadata["prob_map"])
 
             layer_instance: LabelsLayer = layer
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -80,39 +80,38 @@ class ThresholdingService(Subscriber):
             )
         else:
             thresh_function = self._threshold_image
-        for layer in segmentation_labels:
-            # Creating helper functions for mypy strict typing
-            def thresholding_task() -> np.ndarray:
-                # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin
-                # so we are only supporting thresholding images that are from the plugin itself.
-                if (
-                    not isinstance(layer.metadata, dict)
-                    or "prob_map" not in layer.metadata
-                ):
-                    raise ValueError(
-                        "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
+        for idx, layer in enumerate(segmentation_labels):
+            if idx in self._file_input_model.get_selected_idx():
+                # Creating helper functions for mypy strict typing
+                def thresholding_task() -> np.ndarray:
+                    # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin
+                    # so we are only supporting thresholding images that are from the plugin itself.
+                    if (
+                        not isinstance(layer.metadata, dict)
+                        or "prob_map" not in layer.metadata
+                    ):
+                        raise ValueError(
+                            "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
+                        )
+
+                    return thresh_function(layer.metadata["prob_map"])
+
+                def on_return(
+                    threshold_output: np.ndarray,
+                    layer_to_change: LabelsLayer = layer,
+                ) -> None:
+                    self._viewer.insert_threshold(
+                        layer_to_change,
+                        threshold_output,
+                        self._main_model.are_predictions_in_viewer(),
                     )
 
-                return thresh_function(layer.metadata["prob_map"])
-
-            layer_instance: LabelsLayer = layer
-
-            def on_return(
-                threshold_output: np.ndarray,
-                layer_to_change: LabelsLayer = layer_instance,
-            ) -> None:
-                self._viewer.insert_threshold(
-                    layer_to_change,
-                    threshold_output,
-                    self._main_model.are_predictions_in_viewer(),
+                self._task_executor.exec(
+                    task=thresholding_task,
+                    # lambda functions capture variables by reference so need to pass layer as a default argument
+                    on_return=on_return,
+                    on_error=self._handle_thresholding_error,
                 )
-
-            self._task_executor.exec(
-                task=thresholding_task,
-                # lambda functions capture variables by reference so need to pass layer as a default argument
-                on_return=on_return,
-                on_error=self._handle_thresholding_error,
-            )
 
     def _save_thresholded_images(self, _: Event) -> None:
         images_to_threshold: list[Path] = (

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -80,8 +80,7 @@ class ThresholdingService(Subscriber):
             )
         else:
             thresh_function = self._threshold_image
-        for path_layer_to_threshold in self._file_input_model.get_selected_paths():
-            layer: Layer = [x for x in segmentation_labels if x.metadata["source_path"] == path_layer_to_threshold][0]
+        for layer in segmentation_labels:
             # Creating helper functions for mypy strict typing
             def thresholding_task() -> np.ndarray:
                 # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -93,7 +93,7 @@ class ThresholdingService(Subscriber):
                         "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
                     )
 
-                return thresh_function(layer.metadata["prob_map"])
+                return thresh_function(layer.metadata["prob_map"].data)
 
             layer_instance: LabelsLayer = layer
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -101,7 +101,7 @@ class ThresholdingService(Subscriber):
                 threshold_output: np.ndarray,
             ) -> None:
                 self._viewer.insert_threshold(
-                    layer_instance.name,
+                    layer_instance,
                     threshold_output,
                     self._main_model.are_predictions_in_viewer(),
                 )

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -93,7 +93,7 @@ class ThresholdingService(Subscriber):
                         "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
                     )
 
-                return thresh_function(layer.metadata["prob_map"].data)
+                return thresh_function(layer.metadata["prob_map"].np_data)
 
             layer_instance: LabelsLayer = layer
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -81,7 +81,7 @@ class ThresholdingService(Subscriber):
         else:
             thresh_function = self._threshold_image
         for idx, layer in enumerate(segmentation_labels):
-            selected_idx: list[int] | None = (
+            selected_idx: Optional[list[int]] = (
                 self._file_input_model.get_selected_idx()
             )
             if selected_idx is not None and idx in selected_idx:

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -83,25 +83,27 @@ class ThresholdingService(Subscriber):
         for idx, layer in enumerate(segmentation_labels):
             if idx in self._file_input_model.get_selected_idx():
                 # Creating helper functions for mypy strict typing
-                def thresholding_task() -> np.ndarray:
+                def thresholding_task(
+                    layer_instance: Layer = layer,
+                ) -> np.ndarray:
                     # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin
                     # so we are only supporting thresholding images that are from the plugin itself.
                     if (
-                        not isinstance(layer.metadata, dict)
-                        or "prob_map" not in layer.metadata
+                        not isinstance(layer_instance.metadata, dict)
+                        or "prob_map" not in layer_instance.metadata
                     ):
                         raise ValueError(
                             "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
                         )
 
-                    return thresh_function(layer.metadata["prob_map"])
+                    return thresh_function(layer_instance.metadata["prob_map"])
 
                 def on_return(
                     threshold_output: np.ndarray,
-                    layer_to_change: LabelsLayer = layer,
+                    layer_instance: Layer = layer,
                 ) -> None:
                     self._viewer.insert_threshold(
-                        layer_to_change,
+                        layer_instance,
                         threshold_output,
                         self._main_model.are_predictions_in_viewer(),
                     )

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -80,7 +80,8 @@ class ThresholdingService(Subscriber):
             )
         else:
             thresh_function = self._threshold_image
-        for layer in segmentation_labels:
+        for path_layer_to_threshold in self._file_input_model.get_selected_paths():
+            layer: Layer = [x for x in segmentation_labels if x.metadata["source_path"] == path_layer_to_threshold][0]
             # Creating helper functions for mypy strict typing
             def thresholding_task() -> np.ndarray:
                 # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -44,8 +44,6 @@ from qtpy.QtWidgets import (
 from qtpy.QtCore import Qt
 
 
-
-
 class ThresholdingView(View, MainWindow):
     """
     View for thresholding
@@ -87,10 +85,12 @@ class ThresholdingView(View, MainWindow):
         layout.addWidget(self._title, alignment=Qt.AlignmentFlag.AlignHCenter)
 
         # selecting input image
-        self._prediction_result_input_widget: PredictionResultListWidget = PredictionResultListWidget(
-            self._file_input_model,
-            self._viewer,
-            self._input_files_service,
+        self._prediction_result_input_widget: PredictionResultListWidget = (
+            PredictionResultListWidget(
+                self._file_input_model,
+                self._viewer,
+                self._input_files_service,
+            )
         )
         self._prediction_result_input_widget.setObjectName("fileInput")
         layout.addWidget(self._prediction_result_input_widget)

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -21,8 +21,8 @@ from allencell_ml_segmenter.thresholding.thresholding_model import (
 from allencell_ml_segmenter.utils.file_utils import FileUtils
 
 from allencell_ml_segmenter.widgets.label_with_hint_widget import LabelWithHint
-from allencell_ml_segmenter.core.file_input_widget import (
-    FileInputWidget,
+from allencell_ml_segmenter.core.prediction_result_input_widget import (
+    PredictionResultListWidget,
 )
 from allencell_ml_segmenter.core.file_input_model import (
     FileInputModel,
@@ -42,6 +42,8 @@ from qtpy.QtWidgets import (
     QSpinBox,
 )
 from qtpy.QtCore import Qt
+
+
 
 
 class ThresholdingView(View, MainWindow):
@@ -85,14 +87,13 @@ class ThresholdingView(View, MainWindow):
         layout.addWidget(self._title, alignment=Qt.AlignmentFlag.AlignHCenter)
 
         # selecting input image
-        self._file_input_widget: FileInputWidget = FileInputWidget(
+        self._prediction_result_input_widget: PredictionResultListWidget = PredictionResultListWidget(
             self._file_input_model,
             self._viewer,
             self._input_files_service,
-            include_channel_selection=False,
         )
-        self._file_input_widget.setObjectName("fileInput")
-        layout.addWidget(self._file_input_widget)
+        self._prediction_result_input_widget.setObjectName("fileInput")
+        layout.addWidget(self._prediction_result_input_widget)
 
         # thresholding values
         self._threshold_label: LabelWithHint = LabelWithHint("Threshold")
@@ -326,7 +327,7 @@ class ThresholdingView(View, MainWindow):
         self._thresholding_model.dispatch_save_thresholded_images()
 
     def focus_changed(self) -> None:
-        self._file_input_widget._update_layer_list()
+        self._prediction_result_input_widget._update_layer_list()
 
     def getTypeOfWork(self) -> str:
         return ""


### PR DESCRIPTION
## Purpose
Replaces `FileInputWidget` in `ThresholdingView` with a `PredictionResultInputWidget`, which only allows you to select images that are the result of prediction during thresholding.

## Changes

- Created new `PredictionResultInputWidget` which only allows selection of images that are the result from training
- changes to `Viewer`, `ThresholdingView`, `ThresholdingService` to support the above change.
- Changes to variable names in `ThresholdingService` from comments on previous pr by @hughes036 

## Testing
Tested manually on Ec2 instance as well as on my windows machine at home.

## How to review
Start with `ThresholdingView`, and see related changes in `Viewer`, `ThresholdingView`, `ThresholdingService`.
Lastly check out `PredictionResultInputWidget` and changes to `FileInputModel` which the `PredictionResultInputWidget` still uses.
