### PR TITLE
Make ThresholdingModel compose FileInputModel, Add ability to remove binary maps

### DIFF
--- a/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
+++ b/src/allencell_ml_segmenter/_tests/fakes/fake_viewer.py
@@ -145,3 +145,6 @@ class FakeViewer(IViewer):
             if getattr(layer, "metadata", None)
             and "prob_map" in layer.metadata
         ]
+
+    def clear_binary_map_from_layer(self, layer: Layer) -> None:
+        self.threshold_inserted.pop(f"[threshold] {layer.name}")

--- a/src/allencell_ml_segmenter/_tests/main/test_viewer.py
+++ b/src/allencell_ml_segmenter/_tests/main/test_viewer.py
@@ -1,0 +1,12 @@
+from napari.layers import Labels
+import numpy as np
+
+from allencell_ml_segmenter.main.viewer import Viewer
+
+
+def test_clear_binary_map_from_layer() -> None:
+    layer: Labels = Labels(np.ones((10, 10, 10), dtype=bool))
+
+    Viewer.clear_binary_map_from_layer(Viewer, layer)
+
+    assert np.all(layer.data == 0)  # assert all values are now zeros

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_model.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_model.py
@@ -16,29 +16,27 @@ def thresholding_model() -> ThresholdingModel:
 def test_set_thresholding_value_dispatches_event(thresholding_model):
     fake_subscriber: FakeSubscriber = FakeSubscriber()
     thresholding_model.subscribe(
-        Event.ACTION_THRESHOLDING_VALUE_CHANGED,
+        Event.ACTION_EXECUTE_THRESHOLDING,
         fake_subscriber,
         fake_subscriber.handle,
     )
 
     thresholding_model.set_thresholding_value(2)
 
-    assert fake_subscriber.was_handled(Event.ACTION_THRESHOLDING_VALUE_CHANGED)
+    assert fake_subscriber.was_handled(Event.ACTION_EXECUTE_THRESHOLDING)
 
 
 def test_set_autothresholding_enabled_dispatches_event(thresholding_model):
     fake_subscriber: FakeSubscriber = FakeSubscriber()
     thresholding_model.subscribe(
-        Event.ACTION_THRESHOLDING_AUTOTHRESHOLDING_SELECTED,
+        Event.ACTION_EXECUTE_THRESHOLDING,
         fake_subscriber,
         fake_subscriber.handle,
     )
 
     thresholding_model.set_autothresholding_enabled(True)
 
-    assert fake_subscriber.was_handled(
-        Event.ACTION_THRESHOLDING_AUTOTHRESHOLDING_SELECTED
-    )
+    assert fake_subscriber.was_handled(Event.ACTION_EXECUTE_THRESHOLDING)
 
 
 def test_dispatch_save_thresholded_images(thresholding_model):

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -82,10 +82,10 @@ def test_on_threshold_changed_non_prediction(test_image):
         metadata={"prob_map": test_image},
     )
     viewer.add_image(test_image, name="donotthreshold")
-    thresholding_model.set_selected_idx([0, 1])
     thresholding_model.set_thresholding_layers(
         viewer.get_all_layers_containing_prob_map()
     )
+    thresholding_model.set_selected_idx([0, 1])
 
     # ACT set a threshold to trigger
     thresholding_model.set_thresholding_value(50)

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -110,3 +110,121 @@ def test_on_threshold_changed_non_prediction(test_image):
     assert np.array_equal(seg_data, (test_image > 100).astype(int))
     # verify that raw layers do not get thresholded
     assert len(viewer.threshold_inserted) == 2
+
+
+def test_none_selected_removes_binary_maps(test_image):
+    """
+    Test that the thresholding service does not add a threshold layer for a layer that is not a probability map
+    """
+    # ARRANGE
+    thresholding_model: ThresholdingModel = ThresholdingModel()
+    viewer: FakeViewer = FakeViewer()
+    main_model: MainModel = MainModel()
+    main_model.set_predictions_in_viewer(True)
+    thresholding_service: ThresholdingService = ThresholdingService(
+        thresholding_model,
+        FakeExperimentsModel(),
+        main_model,
+        viewer,
+        task_executor=SynchroTaskExecutor.global_instance(),
+    )
+
+    # Only the [seg] layers below should produce a threshold layer since they have prob map metadata
+    viewer.add_image(test_image, name="[raw] test_layer 1")
+    viewer.add_image(
+        test_image,
+        name="[seg] test_layer 1",
+        metadata={"prob_map": test_image},
+    )
+    viewer.add_image(test_image, name="[raw] test_layer 2")
+    viewer.add_image(
+        test_image,
+        name="[seg] test_layer 2",
+        metadata={"prob_map": test_image},
+    )
+    viewer.add_image(test_image, name="donotthreshold")
+    thresholding_model.set_thresholding_layers(
+        viewer.get_all_layers_containing_prob_map()
+    )
+    thresholding_model.set_selected_idx([0, 1])
+
+    # create binary maps and add to viewer
+    thresholding_model.set_thresholding_value(50)
+    thresholding_model.set_threshold_enabled(True)
+
+    # Verify a threshold layer is added for each seg layer
+    assert "[threshold] [seg] test_layer 1" in viewer.threshold_inserted
+    seg_data = viewer.threshold_inserted["[threshold] [seg] test_layer 1"]
+    assert np.array_equal(seg_data, (test_image > 50).astype(int))
+    assert "[threshold] [seg] test_layer 2" in viewer.threshold_inserted
+    seg_data = viewer.threshold_inserted["[threshold] [seg] test_layer 2"]
+    assert np.array_equal(seg_data, (test_image > 50).astype(int))
+    # verify that raw layers do not get thresholded
+    assert len(viewer.threshold_inserted) == 2
+
+    # ACT remove all binary maps by selecting None
+    thresholding_model.disable_all()
+
+    # Assert
+    assert len(viewer.threshold_inserted) == 0
+
+
+def test_unselection_removes_binary_maps(test_image):
+    """
+    Test that the thresholding service does not add a threshold layer for a layer that is not a probability map
+    """
+    # ARRANGE
+    thresholding_model: ThresholdingModel = ThresholdingModel()
+    viewer: FakeViewer = FakeViewer()
+    main_model: MainModel = MainModel()
+    main_model.set_predictions_in_viewer(True)
+    thresholding_service: ThresholdingService = ThresholdingService(
+        thresholding_model,
+        FakeExperimentsModel(),
+        main_model,
+        viewer,
+        task_executor=SynchroTaskExecutor.global_instance(),
+    )
+
+    # Only the [seg] layers below should produce a threshold layer since they have prob map metadata
+    viewer.add_image(test_image, name="[raw] test_layer 1")
+    viewer.add_image(
+        test_image,
+        name="[seg] test_layer 1",
+        metadata={"prob_map": test_image},
+    )
+    viewer.add_image(test_image, name="[raw] test_layer 2")
+    viewer.add_image(
+        test_image,
+        name="[seg] test_layer 2",
+        metadata={"prob_map": test_image},
+    )
+    viewer.add_image(test_image, name="donotthreshold")
+    thresholding_model.set_thresholding_layers(
+        viewer.get_all_layers_containing_prob_map()
+    )
+    thresholding_model.set_selected_idx([0, 1])
+
+    # create binary maps and add to viewer
+    thresholding_model.set_thresholding_value(50)
+    thresholding_model.set_threshold_enabled(True)
+
+    # Verify a threshold layer is added for each seg layer
+    assert "[threshold] [seg] test_layer 1" in viewer.threshold_inserted
+    seg_data = viewer.threshold_inserted["[threshold] [seg] test_layer 1"]
+    assert np.array_equal(seg_data, (test_image > 50).astype(int))
+    assert "[threshold] [seg] test_layer 2" in viewer.threshold_inserted
+    seg_data = viewer.threshold_inserted["[threshold] [seg] test_layer 2"]
+    assert np.array_equal(seg_data, (test_image > 50).astype(int))
+    # verify that raw layers do not get thresholded
+    assert len(viewer.threshold_inserted) == 2
+
+    # ACT remove binary map by unselecting index 1
+    thresholding_model.set_selected_idx(
+        [0]
+    )  # remove 1, which was previously selected
+
+    # Assert
+    assert len(viewer.threshold_inserted) == 1
+    assert "[threshold] [seg] test_layer 2" not in viewer.threshold_inserted
+    assert "[threshold] [seg] test_layer 1" in viewer.threshold_inserted

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -60,11 +60,9 @@ def test_on_threshold_changed_non_prediction(test_image):
     viewer: FakeViewer = FakeViewer()
     main_model: MainModel = MainModel()
     main_model.set_predictions_in_viewer(True)
-    file_input_model: FileInputModel = FileInputModel()
     thresholding_service: ThresholdingService = ThresholdingService(
         thresholding_model,
         FakeExperimentsModel(),
-        file_input_model,
         main_model,
         viewer,
         task_executor=SynchroTaskExecutor.global_instance(),
@@ -84,7 +82,10 @@ def test_on_threshold_changed_non_prediction(test_image):
         metadata={"prob_map": test_image},
     )
     viewer.add_image(test_image, name="donotthreshold")
-    file_input_model.set_selected_idx([0, 1])
+    thresholding_model.set_selected_idx([0, 1])
+    thresholding_model.set_thresholding_layers(
+        viewer.get_all_layers_containing_prob_map()
+    )
 
     # ACT set a threshold to trigger
     thresholding_model.set_thresholding_value(50)

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -87,6 +87,7 @@ def test_on_threshold_changed_non_prediction(test_image):
 
     # ACT set a threshold to trigger
     thresholding_model.set_thresholding_value(50)
+    thresholding_model.set_threshold_enabled(True)
 
     # Verify a threshold layer is added for each seg layer
     assert "[threshold] [seg] test_layer 1" in viewer.threshold_inserted

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_service.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 
-from allencell_ml_segmenter.core.file_input_model import FileInputModel
 from allencell_ml_segmenter._tests.fakes.fake_experiments_model import (
     FakeExperimentsModel,
 )
@@ -29,7 +28,6 @@ def test_on_threshold_changed_non_prediction(test_image):
     thresholding_service: ThresholdingService = ThresholdingService(
         thresholding_model,
         FakeExperimentsModel(),
-        FileInputModel(),
         MainModel(),
         viewer,
         task_executor=SynchroTaskExecutor.global_instance(),

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_view.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_view.py
@@ -28,9 +28,12 @@ def main_model() -> MainModel:
 
 
 @pytest.fixture
-def thresholding_model() -> ThresholdingModel:
+def thresholding_model(tmp_path: Path) -> ThresholdingModel:
     model = ThresholdingModel()
     model.set_thresholding_value(128)
+    model.set_output_directory(tmp_path / "output")
+    model.set_input_image_path(tmp_path / "input")
+    model.set_input_mode(InputMode.FROM_PATH)
     return model
 
 
@@ -66,7 +69,6 @@ def thresholding_view(
     view = ThresholdingView(
         main_model,
         thresholding_model,
-        file_input_model,
         experiments_model,
         viewer,
     )
@@ -176,15 +178,18 @@ def test_update_state_from_radios(thresholding_view, thresholding_model):
 
 
 def test_check_able_to_threshold_valid(
-    main_model, file_input_model, experiments_model, viewer
+    main_model, experiments_model, viewer, tmp_path
 ):
     thresholding_model: ThresholdingModel = ThresholdingModel()
     thresholding_model.set_threshold_enabled(True)
     thresholding_model.set_thresholding_value(100)
+    thresholding_model.set_output_directory(tmp_path / "output")
+    thresholding_model.set_input_image_path(tmp_path / "input")
+    thresholding_model.set_input_mode(InputMode.FROM_PATH)
+
     thresholding_view: ThresholdingView = ThresholdingView(
         main_model,
         thresholding_model,
-        file_input_model,
         experiments_model,
         viewer,
     )
@@ -198,13 +203,11 @@ def test_check_able_to_threshold_no_output_dir(
     thresholding_model: ThresholdingModel = ThresholdingModel()
     thresholding_model.set_threshold_enabled(True)
     thresholding_model.set_thresholding_value(100)
-    file_input_model: FileInputModel = FileInputModel()
-    file_input_model.set_input_mode(InputMode.FROM_PATH)
-    file_input_model.set_input_image_path(Path("fake_path"))
+    thresholding_model.set_input_mode(InputMode.FROM_PATH)
+    thresholding_model.set_input_image_path(Path("fake_path"))
     thresholding_view: ThresholdingView = ThresholdingView(
         main_model,
         thresholding_model,
-        file_input_model,
         experiments_model,
         viewer,
     )
@@ -218,13 +221,11 @@ def test_check_able_to_threshold_no_input_dir(
     thresholding_model: ThresholdingModel = ThresholdingModel()
     thresholding_model.set_threshold_enabled(True)
     thresholding_model.set_thresholding_value(100)
-    file_input_model: FileInputModel = FileInputModel()
-    file_input_model.set_input_mode(InputMode.FROM_PATH)
-    file_input_model.set_output_directory(Path("fake_path"))
+    thresholding_model.set_input_mode(InputMode.FROM_PATH)
+    thresholding_model.set_output_directory(Path("fake_path"))
     thresholding_view: ThresholdingView = ThresholdingView(
         main_model,
         thresholding_model,
-        file_input_model,
         experiments_model,
         viewer,
     )
@@ -238,13 +239,11 @@ def test_check_able_to_threshold_no_input_method(
     thresholding_model: ThresholdingModel = ThresholdingModel()
     thresholding_model.set_threshold_enabled(True)
     thresholding_model.set_thresholding_value(100)
-    file_input_model: FileInputModel = FileInputModel()
-    file_input_model.set_input_image_path(Path("fake_path"))
-    file_input_model.set_output_directory(Path("fake_path"))
+    thresholding_model.set_input_image_path(Path("fake_path"))
+    thresholding_model.set_output_directory(Path("fake_path"))
     thresholding_view: ThresholdingView = ThresholdingView(
         main_model,
         thresholding_model,
-        file_input_model,
         experiments_model,
         viewer,
     )

--- a/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_view.py
+++ b/src/allencell_ml_segmenter/_tests/thresholding/test_thresholding_view.py
@@ -13,7 +13,6 @@ from allencell_ml_segmenter.thresholding.thresholding_model import (
     ThresholdingModel,
 )
 from allencell_ml_segmenter.core.file_input_model import (
-    FileInputModel,
     InputMode,
 )
 from allencell_ml_segmenter._tests.fakes.fake_viewer import FakeViewer
@@ -38,16 +37,6 @@ def thresholding_model(tmp_path: Path) -> ThresholdingModel:
 
 
 @pytest.fixture
-# tmp_path is a builtin pytest fixture for a faked path
-def file_input_model(tmp_path: Path) -> FileInputModel:
-    model = FileInputModel()
-    model.set_output_directory(tmp_path / "output")
-    model.set_input_image_path(tmp_path / "input")
-    model.set_input_mode(InputMode.FROM_PATH)
-    return model
-
-
-@pytest.fixture
 def experiments_model() -> FakeExperimentsModel:
     return FakeExperimentsModel()
 
@@ -61,7 +50,6 @@ def viewer() -> FakeViewer:
 def thresholding_view(
     main_model,
     thresholding_model,
-    file_input_model,
     experiments_model,
     viewer,
     qtbot,

--- a/src/allencell_ml_segmenter/core/event.py
+++ b/src/allencell_ml_segmenter/core/event.py
@@ -65,8 +65,7 @@ class Event(Enum):
     ACTION_CURATION_RAW_THREAD_ERROR = "curation_raw_thread_error"
 
     # Thresholding events
-    ACTION_THRESHOLDING_VALUE_CHANGED = "thresholding_value_changed"
-    ACTION_THRESHOLDING_AUTOTHRESHOLDING_SELECTED = "autothresholding_selected"
+    ACTION_EXECUTE_THRESHOLDING = "execute_thresholding"
     ACTION_SAVE_THRESHOLDING_IMAGES = "save_thresholding_images"
 
     # View selection events. These can stem from a user action, or from a process (i.e. prediction process ends, and a new view is shown automatically).

--- a/src/allencell_ml_segmenter/core/event.py
+++ b/src/allencell_ml_segmenter/core/event.py
@@ -67,6 +67,7 @@ class Event(Enum):
     # Thresholding events
     ACTION_EXECUTE_THRESHOLDING = "execute_thresholding"
     ACTION_SAVE_THRESHOLDING_IMAGES = "save_thresholding_images"
+    ACTION_THRESHOLDING_DISABLED = "disable_thresholding"
 
     # View selection events. These can stem from a user action, or from a process (i.e. prediction process ends, and a new view is shown automatically).
     VIEW_SELECTION_TRAINING = "training_selected"

--- a/src/allencell_ml_segmenter/core/file_input_model.py
+++ b/src/allencell_ml_segmenter/core/file_input_model.py
@@ -93,9 +93,3 @@ class FileInputModel(Publisher):
             if selected_paths is not None:
                 return selected_paths
         return []
-
-    def set_selected_idx(self, selected_idx: list[int]) -> None:
-        self._selected_idx = selected_idx
-
-    def get_selected_idx(self) -> Optional[list[int]]:
-        return self._selected_idx

--- a/src/allencell_ml_segmenter/core/file_input_widget.py
+++ b/src/allencell_ml_segmenter/core/file_input_widget.py
@@ -50,14 +50,14 @@ class FileInputWidget(QWidget):
         self,
         model: FileInputModel,
         viewer: IViewer,
-        service: ModelFileService,
+        service: Optional[ModelFileService],
         include_channel_selection: bool = True,
     ):
         super().__init__()
         self._include_channel_selection: bool = include_channel_selection
         self._model: FileInputModel = model
         self._viewer: IViewer = viewer
-        self._service: ModelFileService = service
+        self._service: Optional[ModelFileService] = service
         layout: QVBoxLayout = QVBoxLayout()
         self.setLayout(layout)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/allencell_ml_segmenter/core/file_input_widget.py
+++ b/src/allencell_ml_segmenter/core/file_input_widget.py
@@ -271,7 +271,8 @@ class FileInputWidget(QWidget):
                     len(selected_indices) == 0
                     and self._include_channel_selection
                 ):
-                    self._service.stop_channel_extraction()  # stop so combobox doesn't reset after thread is finished
+                    if self._service:
+                        self._service.stop_channel_extraction()  # stop so combobox doesn't reset after thread is finished
                     self._reset_channel_combobox()
 
                 self._model.set_selected_paths(

--- a/src/allencell_ml_segmenter/core/thresholding_file_input_widget.py
+++ b/src/allencell_ml_segmenter/core/thresholding_file_input_widget.py
@@ -1,17 +1,12 @@
-from typing import Any, Optional
+from typing import Optional
 
-from napari.layers import Layer
 
 from allencell_ml_segmenter.core.file_input_model import (
     InputMode,
-    FileInputModel,
 )
 from allencell_ml_segmenter.core.file_input_widget import FileInputWidget
 from allencell_ml_segmenter.main.i_viewer import IViewer
-from allencell_ml_segmenter.main.segmenter_layer import LabelsLayer
 from qtpy.QtCore import Qt
-
-from allencell_ml_segmenter.prediction.service import ModelFileService
 
 from napari.utils.events import Event as NapariEvent  # type: ignore
 

--- a/src/allencell_ml_segmenter/core/thresholding_file_input_widget.py
+++ b/src/allencell_ml_segmenter/core/thresholding_file_input_widget.py
@@ -1,5 +1,7 @@
 from typing import Any, Optional
 
+from napari.layers import Layer
+
 from allencell_ml_segmenter.core.file_input_model import (
     InputMode,
     FileInputModel,
@@ -13,27 +15,33 @@ from allencell_ml_segmenter.prediction.service import ModelFileService
 
 from napari.utils.events import Event as NapariEvent  # type: ignore
 
+from allencell_ml_segmenter.thresholding.thresholding_model import (
+    ThresholdingModel,
+)
 
-class PredictionResultListWidget(FileInputWidget):
+
+class ThresholdingFileInputWidget(FileInputWidget):
     """
     Widget containing a list of prediction results that are selectable for thresholding
     """
 
     def __init__(
-        self, model: FileInputModel, viewer: IViewer, service: ModelFileService
+        self,
+        model: ThresholdingModel,
+        viewer: IViewer,
     ):
-        super().__init__(
-            model, viewer, service, include_channel_selection=False
-        )
-        self._prediction_layers: list[LabelsLayer] = []
+        super().__init__(model, viewer, None)
+        self._thresholding_model = model
 
     def _update_layer_list(self, event: Optional[NapariEvent] = None) -> None:
         previous_selections: list[int] = self._image_list.get_checked_rows()
         self._image_list.clear()
-        self._prediction_layers = (
+        self._thresholding_model.set_thresholding_layers(
             self._viewer.get_all_layers_containing_prob_map()
         )
-        for idx, prediction_output_layer in enumerate(self._prediction_layers):
+        for idx, prediction_output_layer in enumerate(
+            self._thresholding_model.get_thresholding_layers()
+        ):
             self._image_list.add_item(
                 prediction_output_layer.name,
                 set_checked=idx in previous_selections,

--- a/src/allencell_ml_segmenter/core/thresholding_file_input_widget.py
+++ b/src/allencell_ml_segmenter/core/thresholding_file_input_widget.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-
 from allencell_ml_segmenter.core.file_input_model import (
     InputMode,
 )
@@ -26,16 +25,16 @@ class ThresholdingFileInputWidget(FileInputWidget):
         viewer: IViewer,
     ):
         super().__init__(model, viewer, None)
-        self._thresholding_model = model
+        self._model: ThresholdingModel = model
 
     def _update_layer_list(self, event: Optional[NapariEvent] = None) -> None:
         previous_selections: list[int] = self._image_list.get_checked_rows()
         self._image_list.clear()
-        self._thresholding_model.set_thresholding_layers(
+        self._model.set_thresholding_layers(
             self._viewer.get_all_layers_containing_prob_map()
         )
         for idx, prediction_output_layer in enumerate(
-            self._thresholding_model.get_thresholding_layers()
+            self._model.get_thresholding_layers()
         ):
             self._image_list.add_item(
                 prediction_output_layer.name,

--- a/src/allencell_ml_segmenter/core/thresholding_file_input_widget.py
+++ b/src/allencell_ml_segmenter/core/thresholding_file_input_widget.py
@@ -24,7 +24,7 @@ class ThresholdingFileInputWidget(FileInputWidget):
         model: ThresholdingModel,
         viewer: IViewer,
     ):
-        super().__init__(model, viewer, None)
+        super().__init__(model, viewer, None, False)
         self._model: ThresholdingModel = model
 
     def _update_layer_list(self, event: Optional[NapariEvent] = None) -> None:

--- a/src/allencell_ml_segmenter/main/i_viewer.py
+++ b/src/allencell_ml_segmenter/main/i_viewer.py
@@ -109,3 +109,7 @@ class IViewer(ABC):
     @abstractmethod
     def get_all_layers_containing_prob_map(self) -> list[Layer]:
         pass
+
+    @abstractmethod
+    def clear_binary_map_from_layer(self, layer: Layer) -> None:
+        pass

--- a/src/allencell_ml_segmenter/main/main_widget.py
+++ b/src/allencell_ml_segmenter/main/main_widget.py
@@ -97,7 +97,6 @@ class MainWidget(AicsWidget):
             self._model,
         )
 
-        self._thresholding_file_input_model: FileInputModel = FileInputModel()
         self._thresholding_model: ThresholdingModel = ThresholdingModel()
 
         # init services
@@ -121,7 +120,6 @@ class MainWidget(AicsWidget):
         self._thresholding_service: ThresholdingService = ThresholdingService(
             thresholding_model=self._thresholding_model,
             experiments_model=self._experiments_model,
-            file_input_model=self._thresholding_file_input_model,
             main_model=self._model,
             viewer=self.viewer,
         )
@@ -161,7 +159,6 @@ class MainWidget(AicsWidget):
         self._thresholding_view = ThresholdingView(
             main_model=self._model,
             thresholding_model=self._thresholding_model,
-            file_input_model=self._thresholding_file_input_model,
             experiments_model=self._experiments_model,
             viewer=self.viewer,
         )

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -158,7 +158,10 @@ class Viewer(IViewer):
         :param remove_seg_layers: boolean indicating if the layer that is being thresholded is a segmentation layer, and should be removed from the layer once it is updated with the threshold.
         """
         # if threshold has not been previously applied, update name
-        if "threshold_applied" not in layer.metadata or not layer.metadata["threshold_applied"]:
+        if (
+            "threshold_applied" not in layer.metadata
+            or not layer.metadata["threshold_applied"]
+        ):
             layer.name = f"[threshold] {layer.name}"
         layer.data = image
         layer.metadata["threshold_applied"] = True
@@ -188,7 +191,13 @@ class Viewer(IViewer):
 
     def clear_binary_map_from_layer(self, layer: Layer) -> None:
         if "threshold_applied" in layer.metadata:
-            layer.metadata["threshold_applied"] = False # so that we know a threshold has no longer been applied to this image
-            layer.name = layer.name.replace("[threshold] ", "") # remove threshold tag from layer name displayed on viewer
-        layer.data = np.zeros(layer.data.shape, dtype=np.uint8) #0-255 is a uint8 image
+            layer.metadata["threshold_applied"] = (
+                False  # so that we know a threshold has no longer been applied to this image
+            )
+            layer.name = layer.name.replace(
+                "[threshold] ", ""
+            )  # remove threshold tag from layer name displayed on viewer
+        layer.data = np.zeros(
+            layer.data.shape, dtype=np.uint8
+        )  # 0-255 is a uint8 image
         layer.refresh()

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -198,6 +198,6 @@ class Viewer(IViewer):
                 "[threshold] ", ""
             )  # remove threshold tag from layer name displayed on viewer
         layer.data = np.zeros(
-            layer.data.shape, dtype=np.uint8
+            layer.data.shape, dtype=bool
         )  # 0-255 is a uint8 image
         layer.refresh()

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -185,3 +185,10 @@ class Viewer(IViewer):
             for layer in self.get_layers()
             if "prob_map" in layer.metadata
         ]
+
+    def clear_binary_map_from_layer(self, layer: Layer) -> None:
+        if "threshold_applied" in layer.metadata:
+            layer.metadata["threshold_applied"] = False # so that we know a threshold has no longer been applied to this image
+            layer.name = layer.name.replace("[threshold] ", "") # remove threshold tag from layer name displayed on viewer
+        layer.data = np.zeros(layer.data.shape)
+        layer.refresh()

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -190,6 +190,10 @@ class Viewer(IViewer):
         ]
 
     def clear_binary_map_from_layer(self, layer: Layer) -> None:
+        """
+        We need to keep the layer because it contains the segmentation's probability map.
+        So, clear out the binary map by setting it to all zeros
+        """
         if "threshold_applied" in layer.metadata:
             layer.metadata["threshold_applied"] = (
                 False  # so that we know a threshold has no longer been applied to this image
@@ -199,5 +203,5 @@ class Viewer(IViewer):
             )  # remove threshold tag from layer name displayed on viewer
         layer.data = np.zeros(
             layer.data.shape, dtype=bool
-        )  # 0-255 is a uint8 image
+        )  # image of type bool
         layer.refresh()

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -158,7 +158,7 @@ class Viewer(IViewer):
         :param remove_seg_layers: boolean indicating if the layer that is being thresholded is a segmentation layer, and should be removed from the layer once it is updated with the threshold.
         """
         # if threshold has not been previously applied, update name
-        if "threshold_applied" not in layer.metadata:
+        if "threshold_applied" not in layer.metadata or not layer.metadata["threshold_applied"]:
             layer.name = f"[threshold] {layer.name}"
         layer.data = image
         layer.metadata["threshold_applied"] = True
@@ -190,5 +190,5 @@ class Viewer(IViewer):
         if "threshold_applied" in layer.metadata:
             layer.metadata["threshold_applied"] = False # so that we know a threshold has no longer been applied to this image
             layer.name = layer.name.replace("[threshold] ", "") # remove threshold tag from layer name displayed on viewer
-        layer.data = np.zeros(layer.data.shape)
+        layer.data = np.zeros(layer.data.shape, dtype=np.uint8) #0-255 is a uint8 image
         layer.refresh()

--- a/src/allencell_ml_segmenter/thresholding/thresholding_model.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_model.py
@@ -1,11 +1,8 @@
 from typing import Optional
-from collections import OrderedDict
-
-import numpy as np
 from napari.layers import Layer  # type: ignore
 
 from allencell_ml_segmenter.core.event import Event
-from allencell_ml_segmenter.core.publisher import Publisher
+from allencell_ml_segmenter.core.file_input_model import FileInputModel
 
 # Some thresholding constants #
 AVAILABLE_AUTOTHRESHOLD_METHODS: list[str] = ["threshold_otsu"]
@@ -13,7 +10,7 @@ THRESHOLD_DEFAULT = 120
 THRESHOLD_RANGE = (0, 255)
 
 
-class ThresholdingModel(Publisher):
+class ThresholdingModel(FileInputModel):
     """
     Stores state relevant to thresholding processes.
     """
@@ -26,13 +23,19 @@ class ThresholdingModel(Publisher):
         self._thresholding_value_selected: int = THRESHOLD_DEFAULT
         self._is_autothresholding_enabled: bool = False
         self._autothresholding_method: str = AVAILABLE_AUTOTHRESHOLD_METHODS[0]
+        self._thresholding_layers: list[Layer] = (
+            []
+        )  # Layers show binary map as data, but contain a metadata
+        # key prob_map which contains the probability map that we need to threshold to generate a binary map with
+        # the set threshold value.
+        self._selected_idx: list[int] = []
 
     def set_thresholding_value(self, value: int) -> None:
         """
         Set the thresholding value.
         """
         self._thresholding_value_selected = value
-        self.dispatch(Event.ACTION_THRESHOLDING_VALUE_CHANGED)
+        self.dispatch(Event.ACTION_EXECUTE_THRESHOLDING)
 
     def get_thresholding_value(self) -> int:
         """
@@ -46,7 +49,7 @@ class ThresholdingModel(Publisher):
         """
         self._is_autothresholding_enabled = enable
         if enable:
-            self.dispatch(Event.ACTION_THRESHOLDING_AUTOTHRESHOLDING_SELECTED)
+            self.dispatch(Event.ACTION_EXECUTE_THRESHOLDING)
 
     def is_autothresholding_enabled(self) -> bool:
         """
@@ -59,7 +62,7 @@ class ThresholdingModel(Publisher):
         Set autothresholding method.
         """
         self._autothresholding_method = method
-        self.dispatch(Event.ACTION_THRESHOLDING_AUTOTHRESHOLDING_SELECTED)
+        self.dispatch(Event.ACTION_EXECUTE_THRESHOLDING)
 
     def get_autothresholding_method(self) -> str:
         """
@@ -81,3 +84,16 @@ class ThresholdingModel(Publisher):
 
     def dispatch_save_thresholded_images(self) -> None:
         self.dispatch(Event.ACTION_SAVE_THRESHOLDING_IMAGES)
+
+    def set_thresholding_layers(self, layers: list[Layer]) -> None:
+        self._thresholding_layers = layers
+
+    def get_thresholding_layers(self) -> list[Layer]:
+        return self._thresholding_layers
+
+    def set_selected_idx(self, selected_idx: list[int]) -> None:
+        self._selected_idx = selected_idx
+        self.dispatch(Event.ACTION_EXECUTE_THRESHOLDING)
+
+    def get_selected_idx(self) -> Optional[list[int]]:
+        return self._selected_idx

--- a/src/allencell_ml_segmenter/thresholding/thresholding_model.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_model.py
@@ -82,6 +82,11 @@ class ThresholdingModel(FileInputModel):
         """
         return self._is_threshold_enabled
 
+    def disable_all(self) -> None:
+        self.set_threshold_enabled(False)
+        self.set_autothresholding_enabled(False)
+        self.dispatch(Event.ACTION_THRESHOLDING_DISABLED)
+
     def dispatch_save_thresholded_images(self) -> None:
         self.dispatch(Event.ACTION_SAVE_THRESHOLDING_IMAGES)
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_model.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_model.py
@@ -75,6 +75,8 @@ class ThresholdingModel(FileInputModel):
         Set threshold specific value.
         """
         self._is_threshold_enabled = enabled
+        if enabled:
+            self.dispatch(Event.ACTION_EXECUTE_THRESHOLDING)
 
     def is_threshold_enabled(self) -> bool:
         """

--- a/src/allencell_ml_segmenter/thresholding/thresholding_model.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_model.py
@@ -102,5 +102,5 @@ class ThresholdingModel(FileInputModel):
         self._selected_idx = selected_idx
         self.dispatch(Event.ACTION_EXECUTE_THRESHOLDING)
 
-    def get_selected_idx(self) -> Optional[list[int]]:
+    def get_selected_idx(self) -> list[int]:
         return self._selected_idx

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -133,6 +133,12 @@ class ThresholdingService(Subscriber):
                     self._viewer.clear_binary_map_from_layer(layer)
 
     def _save_thresholded_images(self, _: Event) -> None:
+        selected_images_viewer: list[Path] = []
+        for idx, layer in self._viewer.get_all_layers_containing_prob_map():
+            if idx in self._thresholding_model.get_selected_idx():
+                selected_images_viewer.append(layer.metadata["source_path"])
+        self._thresholding_model.set_selected_paths(selected_images_viewer)
+
         images_to_threshold: list[Path] = (
             self._thresholding_model.get_input_files_as_list()
         )

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -29,7 +29,6 @@ class ThresholdingService(Subscriber):
         self,
         thresholding_model: ThresholdingModel,
         experiments_model: ExperimentsModel,
-        file_input_model: FileInputModel,
         main_model: MainModel,
         viewer: IViewer,
         task_executor: ITaskExecutor = NapariThreadTaskExecutor.global_instance(),
@@ -38,7 +37,6 @@ class ThresholdingService(Subscriber):
         # Models
         self._thresholding_model: ThresholdingModel = thresholding_model
         self._experiments_model: ExperimentsModel = experiments_model
-        self._file_input_model: FileInputModel = file_input_model
         self._main_model: MainModel = main_model
 
         # napari viewer
@@ -48,13 +46,7 @@ class ThresholdingService(Subscriber):
         self._task_executor: ITaskExecutor = task_executor
 
         self._thresholding_model.subscribe(
-            Event.ACTION_THRESHOLDING_VALUE_CHANGED,
-            self,
-            self._on_threshold_changed,
-        )
-
-        self._thresholding_model.subscribe(
-            Event.ACTION_THRESHOLDING_AUTOTHRESHOLDING_SELECTED,
+            Event.ACTION_EXECUTE_THRESHOLDING,
             self,
             self._on_threshold_changed,
         )
@@ -70,7 +62,7 @@ class ThresholdingService(Subscriber):
 
     def _on_threshold_changed(self, _: Event) -> None:
         layers_containing_prob_map: list[Layer] = (
-            self._viewer.get_all_layers_containing_prob_map()
+            self._thresholding_model.get_thresholding_layers()
         )
 
         # determine thresholding function to use
@@ -82,7 +74,7 @@ class ThresholdingService(Subscriber):
             thresh_function = self._threshold_image
 
         selected_idx: Optional[list[int]] = (
-            self._file_input_model.get_selected_idx()
+            self._thresholding_model.get_selected_idx()
         )
 
         if selected_idx is not None:
@@ -124,7 +116,7 @@ class ThresholdingService(Subscriber):
 
     def _save_thresholded_images(self, _: Event) -> None:
         images_to_threshold: list[Path] = (
-            self._file_input_model.get_input_files_as_list()
+            self._file_input_model.get_input_files_as_list()  # TODO implement
         )
         if self._thresholding_model.is_autothresholding_enabled():
             thresh_function: Callable = AutoThreshold(
@@ -143,7 +135,7 @@ class ThresholdingService(Subscriber):
         self, image: np.ndarray, original_image_name: str
     ) -> None:
         output_directory: Optional[Path] = (
-            self._file_input_model.get_output_directory()
+            self._file_input_model.get_output_directory()  # TODO implement
         )
         if output_directory is not None:
             new_image_path: Path = (

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -65,12 +65,14 @@ class ThresholdingService(Subscriber):
         show_info("Thresholding failed: " + str(error))
 
     def _on_threshold_changed(self, _: Event) -> None:
+        # Check to see if user has selected a thresholding method
         if self._thresholding_model.is_threshold_enabled() or self._thresholding_model.is_autothresholding_enabled():
+            # get all layers with a prob map
             layers_containing_prob_map: list[Layer] = (
                 self._thresholding_model.get_thresholding_layers()
             )
 
-            # determine thresholding function to use
+            # determine thresholding function to use based on user selection
             if self._thresholding_model.is_autothresholding_enabled():
                 thresh_function: Callable = AutoThreshold(
                     self._thresholding_model.get_autothresholding_method()
@@ -78,14 +80,16 @@ class ThresholdingService(Subscriber):
             elif self._thresholding_model.is_threshold_enabled():
                 thresh_function = self._threshold_image
 
-            selected_idx: Optional[list[int]] = (
+            # selected layers in the ui
+            selected_idx: list[int] = (
                 self._thresholding_model.get_selected_idx()
             )
 
             for idx, layer in enumerate(layers_containing_prob_map):
+                # for selected layers, perform thresholding and display the result in the viewer
                 if idx in selected_idx:
-
                     # Creating helper functions for mypy strict typing
+                    # Thresholding function
                     def thresholding_task(
                         layer_instance: Layer = layer,
                     ) -> np.ndarray:
@@ -101,6 +105,7 @@ class ThresholdingService(Subscriber):
                         # This thresholding task returns a binary map
                         return thresh_function(layer_instance.metadata["prob_map"])
 
+                    # On return, display the binary map that was produced from thresholding
                     def on_return(
                         resulting_binary_map: np.ndarray,
                         layer_instance: Layer = layer,
@@ -111,6 +116,7 @@ class ThresholdingService(Subscriber):
                             self._main_model.are_predictions_in_viewer(),
                         )
 
+                    # Task executor to handle this thresholding task
                     self._task_executor.exec(
                         task=thresholding_task,
                         # lambda functions capture variables by reference so need to pass layer as a default argument
@@ -118,6 +124,7 @@ class ThresholdingService(Subscriber):
                         on_error=self._handle_thresholding_error,
                     )
                 else:
+                    # If not selected (or unselected)- clear the binary map from the napari viewer.
                     self._viewer.clear_binary_map_from_layer(
                         layer
                     )

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -8,11 +8,9 @@ import numpy as np
 from napari.utils.notifications import show_info  # type: ignore
 
 from allencell_ml_segmenter.core.event import Event
-from allencell_ml_segmenter.core.file_input_model import FileInputModel
 from allencell_ml_segmenter.core.subscriber import Subscriber
 from allencell_ml_segmenter.main.experiments_model import ExperimentsModel
 from allencell_ml_segmenter.main.main_model import MainModel
-from allencell_ml_segmenter.main.segmenter_layer import LabelsLayer
 from allencell_ml_segmenter.thresholding.thresholding_model import (
     ThresholdingModel,
 )

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -116,7 +116,7 @@ class ThresholdingService(Subscriber):
 
     def _save_thresholded_images(self, _: Event) -> None:
         images_to_threshold: list[Path] = (
-            self._file_input_model.get_input_files_as_list()  # TODO implement
+            self._thresholding_model.get_input_files_as_list()  # TODO implement
         )
         if self._thresholding_model.is_autothresholding_enabled():
             thresh_function: Callable = AutoThreshold(
@@ -135,7 +135,7 @@ class ThresholdingService(Subscriber):
         self, image: np.ndarray, original_image_name: str
     ) -> None:
         output_directory: Optional[Path] = (
-            self._file_input_model.get_output_directory()  # TODO implement
+            self._thresholding_model.get_output_directory()  # TODO implement
         )
         if output_directory is not None:
             new_image_path: Path = (

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -134,7 +134,7 @@ class ThresholdingService(Subscriber):
 
     def _save_thresholded_images(self, _: Event) -> None:
         selected_images_viewer: list[Path] = []
-        for idx, layer in self._viewer.get_all_layers_containing_prob_map():
+        for idx, layer in enumerate(self._viewer.get_all_layers_containing_prob_map()):
             if idx in self._thresholding_model.get_selected_idx():
                 selected_images_viewer.append(layer.metadata["source_path"])
         self._thresholding_model.set_selected_paths(selected_images_viewer)

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -134,7 +134,7 @@ class ThresholdingService(Subscriber):
 
     def _save_thresholded_images(self, _: Event) -> None:
         images_to_threshold: list[Path] = (
-            self._thresholding_model.get_input_files_as_list()  # TODO implement
+            self._thresholding_model.get_input_files_as_list()
         )
         if self._thresholding_model.is_autothresholding_enabled():
             thresh_function: Callable = AutoThreshold(
@@ -153,7 +153,7 @@ class ThresholdingService(Subscriber):
         self, image: np.ndarray, original_image_name: str
     ) -> None:
         output_directory: Optional[Path] = (
-            self._thresholding_model.get_output_directory()  # TODO implement
+            self._thresholding_model.get_output_directory()
         )
         if output_directory is not None:
             new_image_path: Path = (

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -133,12 +133,6 @@ class ThresholdingService(Subscriber):
                     self._viewer.clear_binary_map_from_layer(layer)
 
     def _save_thresholded_images(self, _: Event) -> None:
-        selected_images_viewer: list[Path] = []
-        for idx, layer in enumerate(self._viewer.get_all_layers_containing_prob_map()):
-            if idx in self._thresholding_model.get_selected_idx():
-                selected_images_viewer.append(layer.metadata["source_path"])
-        self._thresholding_model.set_selected_paths(selected_images_viewer)
-
         images_to_threshold: list[Path] = (
             self._thresholding_model.get_input_files_as_list()
         )

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -55,6 +55,12 @@ class ThresholdingService(Subscriber):
             self._save_thresholded_images,
         )
 
+        self._thresholding_model.subscribe(
+            Event.ACTION_THRESHOLDING_DISABLED,
+            self,
+            self._remove_all_prob_maps,
+        )
+
     def _handle_thresholding_error(self, error: Exception) -> None:
         show_info("Thresholding failed: " + str(error))
 
@@ -75,9 +81,8 @@ class ThresholdingService(Subscriber):
             self._thresholding_model.get_selected_idx()
         )
 
-        if selected_idx is not None:
-            for idx in selected_idx:
-                layer: Layer = layers_containing_prob_map[idx]
+        for idx, layer in enumerate(layers_containing_prob_map):
+            if idx in selected_idx:
 
                 # Creating helper functions for mypy strict typing
                 def thresholding_task(
@@ -110,6 +115,10 @@ class ThresholdingService(Subscriber):
                     # lambda functions capture variables by reference so need to pass layer as a default argument
                     on_return=on_return,
                     on_error=self._handle_thresholding_error,
+                )
+            else:
+                self._viewer.clear_binary_map_from_layer(
+                    layer
                 )
 
     def _save_thresholded_images(self, _: Event) -> None:
@@ -146,3 +155,7 @@ class ThresholdingService(Subscriber):
             self._thresholding_model.get_thresholding_value()
         )
         return (image > threshold_value).astype(int)
+
+    def _remove_all_prob_maps(self) -> None:
+        for layer in self._thresholding_model.get_thresholding_layers():
+            self._viewer.clear_binary_map_from_layer(layer)

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -65,61 +65,62 @@ class ThresholdingService(Subscriber):
         show_info("Thresholding failed: " + str(error))
 
     def _on_threshold_changed(self, _: Event) -> None:
-        layers_containing_prob_map: list[Layer] = (
-            self._thresholding_model.get_thresholding_layers()
-        )
-
-        # determine thresholding function to use
-        if self._thresholding_model.is_autothresholding_enabled():
-            thresh_function: Callable = AutoThreshold(
-                self._thresholding_model.get_autothresholding_method()
+        if self._thresholding_model.is_threshold_enabled() or self._thresholding_model.is_autothresholding_enabled():
+            layers_containing_prob_map: list[Layer] = (
+                self._thresholding_model.get_thresholding_layers()
             )
-        else:
-            thresh_function = self._threshold_image
 
-        selected_idx: Optional[list[int]] = (
-            self._thresholding_model.get_selected_idx()
-        )
+            # determine thresholding function to use
+            if self._thresholding_model.is_autothresholding_enabled():
+                thresh_function: Callable = AutoThreshold(
+                    self._thresholding_model.get_autothresholding_method()
+                )
+            elif self._thresholding_model.is_threshold_enabled():
+                thresh_function = self._threshold_image
 
-        for idx, layer in enumerate(layers_containing_prob_map):
-            if idx in selected_idx:
+            selected_idx: Optional[list[int]] = (
+                self._thresholding_model.get_selected_idx()
+            )
 
-                # Creating helper functions for mypy strict typing
-                def thresholding_task(
-                    layer_instance: Layer = layer,
-                ) -> np.ndarray:
-                    # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin
-                    # so we are only supporting thresholding images that are from the plugin itself.
-                    if (
-                        not isinstance(layer_instance.metadata, dict)
-                        or "prob_map" not in layer_instance.metadata
-                    ):
-                        raise ValueError(
-                            "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
+            for idx, layer in enumerate(layers_containing_prob_map):
+                if idx in selected_idx:
+
+                    # Creating helper functions for mypy strict typing
+                    def thresholding_task(
+                        layer_instance: Layer = layer,
+                    ) -> np.ndarray:
+                        # INVARIANT: a segmentation layer must have prob_map in its metadata if it came from our plugin
+                        # so we are only supporting thresholding images that are from the plugin itself.
+                        if (
+                            not isinstance(layer_instance.metadata, dict)
+                            or "prob_map" not in layer_instance.metadata
+                        ):
+                            raise ValueError(
+                                "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
+                            )
+                        # This thresholding task returns a binary map
+                        return thresh_function(layer_instance.metadata["prob_map"])
+
+                    def on_return(
+                        resulting_binary_map: np.ndarray,
+                        layer_instance: Layer = layer,
+                    ) -> None:
+                        self._viewer.insert_binary_map_into_layer(
+                            layer_instance,
+                            resulting_binary_map,
+                            self._main_model.are_predictions_in_viewer(),
                         )
-                    # This thresholding task returns a binary map
-                    return thresh_function(layer_instance.metadata["prob_map"])
 
-                def on_return(
-                    resulting_binary_map: np.ndarray,
-                    layer_instance: Layer = layer,
-                ) -> None:
-                    self._viewer.insert_binary_map_into_layer(
-                        layer_instance,
-                        resulting_binary_map,
-                        self._main_model.are_predictions_in_viewer(),
+                    self._task_executor.exec(
+                        task=thresholding_task,
+                        # lambda functions capture variables by reference so need to pass layer as a default argument
+                        on_return=on_return,
+                        on_error=self._handle_thresholding_error,
                     )
-
-                self._task_executor.exec(
-                    task=thresholding_task,
-                    # lambda functions capture variables by reference so need to pass layer as a default argument
-                    on_return=on_return,
-                    on_error=self._handle_thresholding_error,
-                )
-            else:
-                self._viewer.clear_binary_map_from_layer(
-                    layer
-                )
+                else:
+                    self._viewer.clear_binary_map_from_layer(
+                        layer
+                    )
 
     def _save_thresholded_images(self, _: Event) -> None:
         images_to_threshold: list[Path] = (
@@ -156,6 +157,6 @@ class ThresholdingService(Subscriber):
         )
         return (image > threshold_value).astype(int)
 
-    def _remove_all_prob_maps(self) -> None:
+    def _remove_all_prob_maps(self, _: Event) -> None:
         for layer in self._thresholding_model.get_thresholding_layers():
             self._viewer.clear_binary_map_from_layer(layer)

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -66,7 +66,10 @@ class ThresholdingService(Subscriber):
 
     def _on_threshold_changed(self, _: Event) -> None:
         # Check to see if user has selected a thresholding method
-        if self._thresholding_model.is_threshold_enabled() or self._thresholding_model.is_autothresholding_enabled():
+        if (
+            self._thresholding_model.is_threshold_enabled()
+            or self._thresholding_model.is_autothresholding_enabled()
+        ):
             # get all layers with a prob map
             layers_containing_prob_map: list[Layer] = (
                 self._thresholding_model.get_thresholding_layers()
@@ -103,7 +106,9 @@ class ThresholdingService(Subscriber):
                                 "Layer metadata must be a dictionary containing the 'prob_map' key in order to threshold."
                             )
                         # This thresholding task returns a binary map
-                        return thresh_function(layer_instance.metadata["prob_map"])
+                        return thresh_function(
+                            layer_instance.metadata["prob_map"]
+                        )
 
                     # On return, display the binary map that was produced from thresholding
                     def on_return(
@@ -125,9 +130,7 @@ class ThresholdingService(Subscriber):
                     )
                 else:
                     # If not selected (or unselected)- clear the binary map from the napari viewer.
-                    self._viewer.clear_binary_map_from_layer(
-                        layer
-                    )
+                    self._viewer.clear_binary_map_from_layer(layer)
 
     def _save_thresholded_images(self, _: Event) -> None:
         images_to_threshold: list[Path] = (

--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -58,7 +58,7 @@ class ThresholdingService(Subscriber):
         self._thresholding_model.subscribe(
             Event.ACTION_THRESHOLDING_DISABLED,
             self,
-            self._remove_all_prob_maps,
+            self._remove_all_binary_maps,
         )
 
     def _handle_thresholding_error(self, error: Exception) -> None:
@@ -167,6 +167,6 @@ class ThresholdingService(Subscriber):
         )
         return (image > threshold_value).astype(int)
 
-    def _remove_all_prob_maps(self, _: Event) -> None:
+    def _remove_all_binary_maps(self, _: Event) -> None:
         for layer in self._thresholding_model.get_thresholding_layers():
             self._viewer.clear_binary_map_from_layer(layer)

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -21,8 +21,8 @@ from allencell_ml_segmenter.thresholding.thresholding_model import (
 from allencell_ml_segmenter.utils.file_utils import FileUtils
 
 from allencell_ml_segmenter.widgets.label_with_hint_widget import LabelWithHint
-from allencell_ml_segmenter.core.prediction_result_input_widget import (
-    PredictionResultListWidget,
+from allencell_ml_segmenter.core.thresholding_file_input_widget import (
+    ThresholdingFileInputWidget,
 )
 from allencell_ml_segmenter.core.file_input_model import (
     FileInputModel,
@@ -53,7 +53,6 @@ class ThresholdingView(View, MainWindow):
         self,
         main_model: MainModel,
         thresholding_model: ThresholdingModel,
-        file_input_model: FileInputModel,
         experiments_model: IExperimentsModel,
         viewer: IViewer,
     ):
@@ -63,12 +62,6 @@ class ThresholdingView(View, MainWindow):
         self._experiments_model: IExperimentsModel = experiments_model
         self._viewer: IViewer = viewer
         self._thresholding_model: ThresholdingModel = thresholding_model
-
-        # To manage input files:
-        self._file_input_model: FileInputModel = file_input_model
-        self._input_files_service: ModelFileService = ModelFileService(
-            self._file_input_model
-        )
 
         layout: QVBoxLayout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -85,11 +78,10 @@ class ThresholdingView(View, MainWindow):
         layout.addWidget(self._title, alignment=Qt.AlignmentFlag.AlignHCenter)
 
         # selecting input image
-        self._prediction_result_input_widget: PredictionResultListWidget = (
-            PredictionResultListWidget(
-                self._file_input_model,
+        self._prediction_result_input_widget: ThresholdingFileInputWidget = (
+            ThresholdingFileInputWidget(
+                self._thresholding_model,
                 self._viewer,
-                self._input_files_service,
             )
         )
         self._prediction_result_input_widget.setObjectName("fileInput")
@@ -275,25 +267,26 @@ class ThresholdingView(View, MainWindow):
     def _check_able_to_threshold(self) -> bool:
         able_to_threshold: bool = True
         # Check to see if output directory is selected
-        if self._file_input_model.get_output_directory() is None:
+        if self._thresholding_model.get_output_directory() is None:
             show_info("Please select an output directory first.")
             able_to_threshold = False
 
         # Check to see if input images / directory of images are selected
-        if self._file_input_model.get_input_mode() is None:
+        if self._thresholding_model.get_input_mode() is None:
             show_info("Please select an input mode first.")
             able_to_threshold = False
         else:
             if (
-                self._file_input_model.get_input_mode()
+                self._thresholding_model.get_input_mode()
                 == InputMode.FROM_NAPARI_LAYERS
-                and self._file_input_model.get_selected_paths() is None
+                and self._thresholding_model.get_selected_paths() is None
             ):
                 show_info("Please select on screen images to threshold.")
                 able_to_threshold = False
             elif (
-                self._file_input_model.get_input_mode() == InputMode.FROM_PATH
-                and self._file_input_model.get_input_image_path() is None
+                self._thresholding_model.get_input_mode()
+                == InputMode.FROM_PATH
+                and self._thresholding_model.get_input_image_path() is None
             ):
                 show_info("Please select a directory to threshold.")
                 able_to_threshold = False

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -313,7 +313,7 @@ class ThresholdingView(View, MainWindow):
             progress_tracker: PredictionFolderProgressTracker = (
                 PredictionFolderProgressTracker(
                     output_dir,
-                    len(self._thresholding_model.get_input_files_as_list()),
+                    len(self._thresholding_model.get_selected_idx()),
                 )
             )
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -308,12 +308,18 @@ class ThresholdingView(View, MainWindow):
         output_dir: Optional[Path] = (
             self._thresholding_model.get_output_directory()
         )
+        selected_images_viewer: list[Path] = []
+        for idx, layer in enumerate(self._viewer.get_all_layers_containing_prob_map()):
+            if idx in self._thresholding_model.get_selected_idx():
+                selected_images_viewer.append(layer.metadata["source_path"])
+        self._thresholding_model.set_selected_paths(selected_images_viewer)
+
         if output_dir is not None and self._check_able_to_threshold():
             # progress tracker is tracking number of images saved to the thresholding folder
             progress_tracker: PredictionFolderProgressTracker = (
                 PredictionFolderProgressTracker(
                     output_dir,
-                    len(self._thresholding_model.get_selected_idx()),
+                    len(self._thresholding_model.get_selected_paths()),
                 )
             )
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -303,14 +303,14 @@ class ThresholdingView(View, MainWindow):
 
     def _save_thresholded_images(self) -> None:
         output_dir: Optional[Path] = (
-            self._file_input_model.get_output_directory()
+            self._thresholding_model.get_output_directory()
         )
         if output_dir is not None and self._check_able_to_threshold():
             # progress tracker is tracking number of images saved to the thresholding folder
             progress_tracker: PredictionFolderProgressTracker = (
                 PredictionFolderProgressTracker(
                     output_dir,
-                    len(self._file_input_model.get_input_files_as_list()),
+                    len(self._thresholding_model.get_input_files_as_list()),
                 )
             )
 
@@ -327,11 +327,11 @@ class ThresholdingView(View, MainWindow):
 
     def showResults(self) -> None:
         dialog_box = DialogBox(
-            f"Predicted images saved to {str(self._file_input_model.get_output_directory())}. \nWould you like to open this folder?"
+            f"Predicted images saved to {str(self._thresholding_model.get_output_directory())}. \nWould you like to open this folder?"
         )
         dialog_box.exec()
         output_dir: Optional[Path] = (
-            self._file_input_model.get_output_directory()
+            self._thresholding_model.get_output_directory()
         )
 
         if output_dir and dialog_box.get_selection():

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -319,7 +319,7 @@ class ThresholdingView(View, MainWindow):
             progress_tracker: PredictionFolderProgressTracker = (
                 PredictionFolderProgressTracker(
                     output_dir,
-                    len(self._thresholding_model.get_selected_paths()),
+                    len(self._thresholding_model.get_input_files_as_list()),
                 )
             )
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -25,7 +25,6 @@ from allencell_ml_segmenter.core.thresholding_file_input_widget import (
     ThresholdingFileInputWidget,
 )
 from allencell_ml_segmenter.core.file_input_model import (
-    FileInputModel,
     InputMode,
 )
 

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -247,12 +247,12 @@ class ThresholdingView(View, MainWindow):
         self._thresholding_model.set_autothresholding_enabled(
             self._autothreshold_radio_button.isChecked()
         )
-        self._autothreshold_method_combo.setEnabled(
-            self._autothreshold_radio_button.isChecked()
-        )
-
         self._thresholding_model.set_threshold_enabled(
             self._specific_value_radio_button.isChecked()
+        )
+
+        self._autothreshold_method_combo.setEnabled(
+            self._autothreshold_radio_button.isChecked()
         )
         self._enable_specific_threshold_widgets(
             self._specific_value_radio_button.isChecked()
@@ -264,6 +264,7 @@ class ThresholdingView(View, MainWindow):
         )
 
     def _disable_all_thresholding(self) -> None:
+        #TODO handle disabling ui for thresh autothresh
         self._thresholding_model.disable_all()
 
     def _check_able_to_threshold(self) -> bool:
@@ -281,7 +282,7 @@ class ThresholdingView(View, MainWindow):
             if (
                 self._thresholding_model.get_input_mode()
                 == InputMode.FROM_NAPARI_LAYERS
-                and self._thresholding_model.get_selected_paths() is None
+                and len(self._thresholding_model.get_selected_idx()) == 0
             ):
                 show_info("Please select on screen images to threshold.")
                 able_to_threshold = False

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -264,7 +264,7 @@ class ThresholdingView(View, MainWindow):
         )
 
     def _disable_all_thresholding(self) -> None:
-        #TODO handle disabling ui for thresh autothresh
+        # TODO handle disabling ui for thresh autothresh
         self._thresholding_model.disable_all()
 
     def _check_able_to_threshold(self) -> bool:
@@ -309,7 +309,9 @@ class ThresholdingView(View, MainWindow):
             self._thresholding_model.get_output_directory()
         )
         selected_images_viewer: list[Path] = []
-        for idx, layer in enumerate(self._viewer.get_all_layers_containing_prob_map()):
+        for idx, layer in enumerate(
+            self._viewer.get_all_layers_containing_prob_map()
+        ):
             if idx in self._thresholding_model.get_selected_idx():
                 selected_images_viewer.append(layer.metadata["source_path"])
         self._thresholding_model.set_selected_paths(selected_images_viewer)

--- a/src/allencell_ml_segmenter/thresholding/thresholding_view.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_view.py
@@ -193,7 +193,7 @@ class ThresholdingView(View, MainWindow):
         )
 
         # update state and ui based on radio button selections
-        self._none_radio_button.toggled.connect(self._update_state_from_radios)
+        self._none_radio_button.toggled.connect(self._disable_all_thresholding)
         self._specific_value_radio_button.toggled.connect(
             self._update_state_from_radios
         )
@@ -262,6 +262,9 @@ class ThresholdingView(View, MainWindow):
             self._specific_value_radio_button.isChecked()
             or self._autothreshold_radio_button.isChecked()
         )
+
+    def _disable_all_thresholding(self) -> None:
+        self._thresholding_model.disable_all()
 
     def _check_able_to_threshold(self) -> bool:
         able_to_threshold: bool = True


### PR DESCRIPTION
## Purpose
This PR resolves two things:
- Refactor:`ThresholdingModel` now inherits `FileInputModel`, so that all UI state is reflected in a single location (`ThresholdingModel`). `ThresholdingService` references state in a single location (`ThresholdingModel`), updating the viewer as the user selects/unselects images and thresholding methods.

- Bugfix: unselecting an image does not clear the binary map for that image.
- Bugfix: selecting (None) in the UI does not clear out all binary maps generated from thresholding

A short video demo of the last two points:
https://github.com/user-attachments/assets/cf1e6a9d-2b21-41bb-90fe-e494a9b54fb3

## Changes
- `ThresholdingModel` now extends `FileInputModel`, this is the single source of truth for thresholding state. before, we stored state from `ThresholdingFileInputWidget` and `ThresholdingView` in separate places. Now this model stores all thresholding state.
- Any UI updates that should trigger a new binary map to be generated or removed from the viewer fire a single event, `Event.ACTION_EXECUTE_THRESHOLDING`. Based on UI state, the `ThresholdingService` handles this event, generates binary maps, and updates the viewer as needed.
- When unselecting an image, the binary map for that image is cleared in the napari viewer.
- When selecting "None" for the thresholding methods in the viewer, all binary maps are cleared.


## Testing
Unit tests, tested on windows

## How to review
1. Start with `ThresholdingModel` and see how it composes `FileInputModel` to use with `ThresholdingFileInputWidget` as well as the `ThresholdingView`
2. See the event handler in `ThresholdingService._on_threshold_changed` which handles all threshold events and updates the viewer as needed. This now includes logic to remove binary maps from the viewer when they are unselected.
3. There is a new `Viewer` function to remove a binary map from a layer. This is done by creating a image of all zeros using `np.zeros()` and adding that as a placeholder when we do not want to display any binary map in a layer. We want to keep the layer, since it contains the original probability map in its metadata that we will need if this layer needs to be thresholded again.
4. `TestThresholdingService` contains two new tests which ensure that images are removed when they are unselected or if None is selected as the thresholding method.
