### PR TITLE
Pin tiffile to working versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "numpy",
     "hydra-core==1.3.2",
     "bioio==1.1.0",
-    "tifffile==2024.9.20",
+    "tifffile>=2023.4.12,<2025.2.18",
     "watchdog",
     "cyto-dl>=0.4.4",
     "scikit-image!=0.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "numpy",
     "hydra-core==1.3.2",
     "bioio==1.1.0",
-    "tifffile>=2023.4.12",
+    "tifffile==2024.9.20",
     "watchdog",
     "cyto-dl>=0.4.4",
     "scikit-image!=0.23.0",


### PR DESCRIPTION
## Purpose
Pinning tiffile to an older version which is supported by our plugin. https://pypi.org/project/tifffile/2025.2.18/
2025.2.18 contains changes to `tifffile` which break image loading through `bioio`. When loading an image, resolution unit is set which gives the error `'_TIFF' object has no attribute 'RESUNIT'`

Historically, we need versions `>=2023.4.12`. Adding `<2025.2.18` to prevent grabbing new version of tiffile with breaking changes. This should let pip grab the latest version of tiffile supported by python 3.9 or 3.10 depending on what user is using.


## Changes
Pins tiffile to working versions

## Testing
Tested w/ a fresh install on windows.

## How to review
one liner