### PR TITLE
fix workflow to auto-add issues to the correct board

### DIFF
--- a/.github/workflows/auto_add_bug_tickets_to_project.yaml
+++ b/.github/workflows/auto_add_bug_tickets_to_project.yaml
@@ -10,8 +10,7 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'Bug Reports')
     steps:
       - name: Add bug issue to project
-        uses: actions/add-to-project@v1
+        uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/AllenCell/projects/10
-          content-id: ${{ github.event.issue.node_id }}
-          column-name: Todo
+          github-token: ${{ secrets.PROJECT_AUTOMATION_PAT }}

--- a/.github/workflows/auto_add_dev_tickets_to_project.yaml
+++ b/.github/workflows/auto_add_dev_tickets_to_project.yaml
@@ -12,8 +12,7 @@ jobs:
         if: |
           !contains(github.event.issue.labels.*.name, 'Requests') &&
           !contains(github.event.issue.labels.*.name, 'Bug Reports')
-        uses: actions/add-to-project@v1
+        uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/AllenCell/projects/7
-          content-id: ${{ github.event.issue.node_id }}
-          column-name: Backlog
+          github-token: ${{ secrets.PROJECT_AUTOMATION_PAT }}

--- a/.github/workflows/auto_add_feature_request_to_project.yaml
+++ b/.github/workflows/auto_add_feature_request_to_project.yaml
@@ -10,8 +10,7 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'Requests')
     steps:
       - name: Add issue to project
-        uses: actions/add-to-project@v1
+        uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/AllenCell/projects/9
-          content-id: ${{ github.event.issue.node_id }}
-          column-name: Scoping
+          github-token: ${{ secrets.PROJECT_AUTOMATION_PAT }}


### PR DESCRIPTION
## Purpose
Fixes our issue workflow.
It seems like `actions/add-to-project@v1` is outdated. I've updated this to use `actions/add-to-project@v1.0.2` instead. There are a couple other options for this action, but this is the only one that is github official.

## Changes

- Changing to use `actions/add-to-project@v1.0.2`.
- `actions/add-to-project@v1.0.2` doesnt support specifying a column name in the project to add this issue to so this was removed. It seems like the way github wants us to use this is by specifying a default column in each project -> done
- we no longer need to specify `content-id` as this action handles this automatically.
- I created a new fine-graned PAT that allows this workflow to see issues/project board and be able to read/write to them.

## Testing
Cant really test this without running a workflow- will need to merge and check

## How to review
3 workflow files edited.