### PR TITLE
ignore large files with git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.png filter=lfs diff=lfs merge=lfs -text
+.jpeg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Purpose
Ignores large binary files (like png images) in git diffs for PR's

[Git LFS docs](https://git-lfs.com/)

## Changes
will make it so that images dont add tons of lines in pr diffs
All changes were created by running `git lfs track`. We are tracking `.png` and `.jpeg` for now with git lfs
