### PR TITLE
Fix images in sphinx docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-.png filter=lfs diff=lfs merge=lfs -text
-.jpeg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Purpose
Looks like the docs were deployed correctly to https://allencell.github.io/allencell-segmenter-ml/index.html, but no images show currently as they are git-lfs objects ([which I have found cannot be used with github pages](https://stackoverflow.com/questions/76689422/with-git-lfs-images-are-not-rendered-correctly-in-github-pages)).

I need to make 2 changes- this pr will remove git lfs tracking, and the next pr will re-add all images as .png binary files which should display correctly on our sphinx docs site.

## Changes
remove .gitattributes that contains lfs tracking
