### PR TITLE
Fix help text

### DIFF
--- a/src/allencell_ml_segmenter/training/model_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/model_selection_widget.py
@@ -76,7 +76,12 @@ class ModelSelectionWidget(QWidget):
         # Help menu, implemented using a combo box to conform to mockup
         self.help_combo_box: QComboBox = QComboBox()
         self.help_combo_box.setFixedWidth(100)
-        self.help_combo_box.setPlaceholderText("Help")
+        # Add placeholder "Help" text idx 0
+        self.help_combo_box.addItem("Help")
+        self.help_combo_box.model().item(0).setEnabled(
+            False
+        )  # Make it unselectable
+        self.help_combo_box.setCurrentIndex(0)
         self.help_combo_box.addItems(
             [
                 ModelSelectionWidget.TUTORIAL_TEXT,
@@ -243,7 +248,7 @@ class ModelSelectionWidget(QWidget):
             self._refresh_experiment_options()
 
         # reset the combo box, so that it bahaves more like a menu
-        self.help_combo_box.setCurrentIndex(-1)
+        self.help_combo_box.setCurrentIndex(0)
 
     def _model_radio_handler(self) -> None:
         self._main_model.set_new_model(self._radio_new_model.isChecked())

--- a/src/allencell_ml_segmenter/training/model_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/model_selection_widget.py
@@ -78,7 +78,6 @@ class ModelSelectionWidget(QWidget):
         self.help_combo_box.setFixedWidth(100)
         # Add placeholder "Help" text idx 0
         self.help_combo_box.addItem("Help")
-        self.help_combo_box.setItemData(0, 0, 0)  # Make it unselectable
         self.help_combo_box.setCurrentIndex(0)
         self.help_combo_box.addItems(
             [

--- a/src/allencell_ml_segmenter/training/model_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/model_selection_widget.py
@@ -78,9 +78,7 @@ class ModelSelectionWidget(QWidget):
         self.help_combo_box.setFixedWidth(100)
         # Add placeholder "Help" text idx 0
         self.help_combo_box.addItem("Help")
-        self.help_combo_box.model().item(0).setEnabled(
-            False
-        )  # Make it unselectable
+        self.help_combo_box.setItemData(0, 0, 0)  # Make it unselectable
         self.help_combo_box.setCurrentIndex(0)
         self.help_combo_box.addItems(
             [


### PR DESCRIPTION
## Purpose
Fixes "Help" dropdown text not showing on windows computers.
On macOs/Linux it seems like `QComboBox.setPlaceholderText()` works as intended, but PyQt5 users report that on windows `placeholderText` does not appear unless the combo box is editable. Our dropdown is not editable since it is a selection dropdown

## Changes
in src/allencell_ml_segmenter/training/model_selection_widget.py: Fixed the dropdown placeholder text by adding it as an item at index 0, which achieves the same behavior as `placeholderText` 

## Testing
Tested on windows

## How to review
One file changed