### PR TITLE
Last minute UI fixes

### DIFF
--- a/src/allencell_ml_segmenter/training/model_selection_widget.py
+++ b/src/allencell_ml_segmenter/training/model_selection_widget.py
@@ -35,7 +35,7 @@ class ModelSelectionWidget(QWidget):
     """
 
     TITLE_TEXT: str = "Segmentation model"
-    TUTORIAL_TEXT: str = "Tutorial"
+    USER_GUIDE_TEXT: str = "User Guide"
     GITHUB_TEXT: str = "GitHub"
     FORUM_TEXT: str = "Forum"
     WEBSITE_TEXT: str = "Website"
@@ -81,7 +81,7 @@ class ModelSelectionWidget(QWidget):
         self.help_combo_box.setCurrentIndex(0)
         self.help_combo_box.addItems(
             [
-                ModelSelectionWidget.TUTORIAL_TEXT,
+                ModelSelectionWidget.USER_GUIDE_TEXT,
                 ModelSelectionWidget.GITHUB_TEXT,
                 ModelSelectionWidget.FORUM_TEXT,
                 ModelSelectionWidget.WEBSITE_TEXT,
@@ -218,9 +218,9 @@ class ModelSelectionWidget(QWidget):
         Triggered when the user selects an option from the help combo box.
         Opens the selected help page.
         """
-        if text == ModelSelectionWidget.TUTORIAL_TEXT:
+        if text == ModelSelectionWidget.USER_GUIDE_TEXT:
             webbrowser.open(
-                "https://www.allencell.org/allencell-segmenter-ml-tutorials.html"
+                "https://allencell.github.io/allencell-segmenter-ml/index.html"
             )
         elif text == ModelSelectionWidget.GITHUB_TEXT:
             webbrowser.open(

--- a/src/allencell_ml_segmenter/widgets/model_download_dialog.py
+++ b/src/allencell_ml_segmenter/widgets/model_download_dialog.py
@@ -42,7 +42,9 @@ class ModelDownloadDialog(QDialog):
         self._model_select_dropdown.addItems(self._available_models.keys())
 
         self._download_button: QPushButton = QPushButton("Download")
-        self._doc_button: QPushButton = QPushButton("Citation and Documentation")
+        self._doc_button: QPushButton = QPushButton(
+            "Citation and Documentation"
+        )
 
         self._download_button.clicked.connect(self._download_button_handler)
         self._doc_button.clicked.connect(self._doc_button_handler)

--- a/src/allencell_ml_segmenter/widgets/model_download_dialog.py
+++ b/src/allencell_ml_segmenter/widgets/model_download_dialog.py
@@ -42,7 +42,7 @@ class ModelDownloadDialog(QDialog):
         self._model_select_dropdown.addItems(self._available_models.keys())
 
         self._download_button: QPushButton = QPushButton("Download")
-        self._doc_button: QPushButton = QPushButton("Documentation")
+        self._doc_button: QPushButton = QPushButton("Citation and Documentation")
 
         self._download_button.clicked.connect(self._download_button_handler)
         self._doc_button.clicked.connect(self._doc_button_handler)
@@ -53,7 +53,7 @@ class ModelDownloadDialog(QDialog):
 
     def _doc_button_handler(self) -> None:
         webbrowser.open(
-            "https://github.com/AllenCell/allencell-segmenter-ml/blob/main/docs/models.md"
+            "https://allencell.github.io/allencell-segmenter-ml/1_Get-started/4_pretrained-models.html"
         )
 
     def _download_button_handler(self) -> None:


### PR DESCRIPTION
## Purpose
Last minute UI fixes that was requested by @thao-do and @gamlinc.


## Changes

- In help menu change`Tutorial` to `User Guide`, and link to new sphinx docs: https://github.com/orgs/AllenCell/projects/9/views/1?pane=issue&itemId=102922616&issue=AllenCell%7Callencell-segmenter-ml%7C603
- In model download dialog change `Documentation` to `Citation and Documentation` and link to new sphinx docs: https://github.com/orgs/AllenCell/projects/9/views/1?pane=issue&itemId=106120543&issue=AllenCell%7Callencell-segmenter-ml%7C614


## Testing
Tested on osx, unit tests
