### PR TITLE
fix int issue macs

### DIFF
--- a/src/allencell_ml_segmenter/thresholding/thresholding_service.py
+++ b/src/allencell_ml_segmenter/thresholding/thresholding_service.py
@@ -162,10 +162,10 @@ class ThresholdingService(Subscriber):
             OmeTiffWriter.save(image, str(new_image_path))
 
     def _threshold_image(self, image: np.ndarray) -> np.ndarray:
-        threshold_value: float = (
+        threshold_value: int = (
             self._thresholding_model.get_thresholding_value()
         )
-        return (image > threshold_value).astype(int)
+        return (image > threshold_value).astype(np.uint8)
 
     def _remove_all_binary_maps(self, _: Event) -> None:
         for layer in self._thresholding_model.get_thresholding_layers():


### PR DESCRIPTION
## Purpose
This addresses thao's issue with thresholding on macs as described in this [slack thread.](https://allencellscience.slack.com/archives/C031ETS45L0/p1746212968231369)

The error `Ome utils can't resolve pixel type: int64` is due to the thresholding function. Currently we have been converting the resulting numpy array of thresholding to an array of `int`.
```
(image > threshold_value).astype(int)
```
This results in different different behavior on different platforms. The numpy `int` type = int32 on windows and linux (https://stackoverflow.com/questions/36278590/numpy-array-dtype-is-coming-as-int32-by-default-in-a-windows-10-64-bit-machine) (even on 64 bit machines) while osx's `int` type = int64 (https://stackoverflow.com/a/48171511) (unless you have a 32 bit mac machine).

Anyways, this means that the numpy array will become int64 on macs which is not possible for `ome-types` to handle when we try to display it. 

## Changes
Fixes the above issue by converting the output of prediction to `uint8` specifically (which ome-types can handle).

Also changed `thresholding_value` to be an `int`, which it should have been before.

## Testing
Testing took forever since segmentation took like an hour on mac but we've verified it works now on macs. windows functionality is the same.

## How to review
two liner