### PR TITLE
fix osx multithread pytorch issue

### DIFF
--- a/src/allencell_ml_segmenter/services/prediction_service.py
+++ b/src/allencell_ml_segmenter/services/prediction_service.py
@@ -1,4 +1,5 @@
 import csv
+from sys import platform
 
 from allencell_ml_segmenter.core.subscriber import Subscriber
 from allencell_ml_segmenter.core.event import Event
@@ -174,6 +175,11 @@ class PredictionService(Subscriber):
             overrides["trainer.accelerator"] = "gpu"
         else:
             overrides["trainer.accelerator"] = "cpu"
+
+        # pytorch needs num_workers = 0 for mac osx
+        # keeps prediction on main thread
+        if platform.system() == "Darwin":
+            overrides["data.num_workers"] = 0
 
         return overrides
 

--- a/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
+++ b/src/allencell_ml_segmenter/utils/cyto_overrides_manager.py
@@ -1,3 +1,4 @@
+from sys import platform
 from typing import Dict, Union, Optional, List
 
 from allencell_ml_segmenter.main.experiments_model import ExperimentsModel
@@ -69,6 +70,11 @@ class CytoDLOverridesManager:
         else:
             overrides_dict["trainer.accelerator"] = "cpu"
         overrides_dict["data.num_workers"] = CUDAUtils.get_num_workers()
+
+        # pytorch needs num_workers = 0 for mac osx
+        # keeps prediction on main thread
+        if platform.system() == "Darwin":
+            overrides_dict["data.num_workers"] = 0
 
         # Spatial Dims (required)
         dims: Optional[int] = self._training_model.get_spatial_dims()


### PR DESCRIPTION
## Purpose
fixes issue that thao reported re: setting `num_workers` override on mac. Pytorch only supports `num_workers=0` on macs currently.

## Changes
Sets `num_workers` to 0 if running on mac
