### PR TITLE
Remove timeout functionality

### DIFF
--- a/docs/user_docs/conf.py
+++ b/docs/user_docs/conf.py
@@ -10,7 +10,7 @@
 project = "Segmenter ML Plugin for napari"
 copyright = "2024, Allen Institute for Cell Science"
 author = "Segmenter ML plugin team"
-release = "1.0.0rc8"
+release = "1.0.0rc9"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 # https://peps.python.org/pep-0621/
 [project]
 name = "allencell-segmenter-ml"
-version = "1.0.0rc8"
+version = "1.0.0rc9"
 description = "A plugin to leverage ML segmentation in napari"
 readme = "README.md"
 requires-python = ">=3.9,<3.11"
@@ -118,7 +118,7 @@ where = ["src"]
 
 # https://pypi.org/project/bumpver
 [tool.bumpver]
-current_version = "1.0.0rc8"
+current_version = "1.0.0rc9"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/src/allencell_ml_segmenter/__init__.py
+++ b/src/allencell_ml_segmenter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0rc8"
+__version__ = "1.0.0rc9"
 
 from allencell_ml_segmenter.napari.napari_reader import napari_get_reader
 from allencell_ml_segmenter.napari.sample_data import make_sample_data

--- a/src/allencell_ml_segmenter/_tests/training/test_view.py
+++ b/src/allencell_ml_segmenter/_tests/training/test_view.py
@@ -100,46 +100,6 @@ def test_set_max_epoch(
     assert training_model.get_num_epochs() == 100
 
 
-def test_set_max_time(
-    qtbot: QtBot, training_view: TrainingView, training_model: TrainingModel
-) -> None:
-    """
-    Tests that the max time field is properly set by the associated QLineEdit.
-    """
-    # ACT
-    with qtbot.waitSignal(training_view._max_time_checkbox.toggled):
-        training_view._max_time_checkbox.click()  # enables the QLineEdit
-
-    qtbot.keyClicks(training_view._max_time_in_minutes_input, "30")
-
-    # ASSERT
-    assert training_model.get_max_time() == 30
-
-
-def test_checkbox_slot(
-    qtbot: QtBot, training_view: TrainingView, training_model: TrainingModel
-) -> None:
-    """
-    Test the slot connected to the timeout checkbox.
-    """
-    # ASSERT (QLineEdit related to timeout limit is disabled by default)
-    assert not training_view._max_time_in_minutes_input.isEnabled()
-
-    # ACT (enable QLineEdit related to timeout limit)
-    with qtbot.waitSignal(training_view._max_time_checkbox.stateChanged):
-        training_view._max_time_checkbox.click()
-
-    # ASSERT
-    assert training_view._max_time_in_minutes_input.isEnabled()
-
-    # ACT (disabled QLineEdit related to timeout limit)
-    with qtbot.waitSignal(training_view._max_time_checkbox.stateChanged):
-        training_view._max_time_checkbox.click()
-
-    # ASSERT
-    assert not training_view._max_time_in_minutes_input.isEnabled()
-
-
 def test_set_model_size(
     training_view: TrainingView, training_model: TrainingModel
 ) -> None:

--- a/src/allencell_ml_segmenter/core/view.py
+++ b/src/allencell_ml_segmenter/core/view.py
@@ -41,7 +41,7 @@ class View(QWidget, Subscriber, metaclass=ViewMeta):
 
         self.progressDialog = QProgressDialog(
             f"{self.getTypeOfWork()} in Progress",
-            "Cancel",
+            None,
             progress_tracker.get_progress_minimum(),
             progress_tracker.get_progress_maximum(),
             self,
@@ -51,9 +51,11 @@ class View(QWidget, Subscriber, metaclass=ViewMeta):
         self.progressDialog.setWindowModality(
             Qt.WindowModality.ApplicationModal
         )
-        self.progressDialog.canceled.connect(self.longTaskThread.terminate)
-        # stop the watchdog thread for file watching inside of the progress tracker
-        self.progressDialog.canceled.connect(progress_tracker.stop_tracker)
+
+        # Cancel functionality removed for now- freezes app on some occasions
+        # TODO: reimplement this using a process within the thread in the future.
+        # self.progressDialog.canceled.connect(self.longTaskThread.terminate)
+        # self.progressDialog.canceled.connect(progress_tracker.stop_tracker)
 
         self.progressDialog.show()
 

--- a/src/allencell_ml_segmenter/training/view.py
+++ b/src/allencell_ml_segmenter/training/view.py
@@ -213,36 +213,6 @@ class TrainingView(View, MainWindow):
         )
         bottom_grid_layout.addWidget(self._num_epochs_input, 3, 1)
 
-        max_time_layout: QHBoxLayout = QHBoxLayout()
-        max_time_layout.setSpacing(0)
-
-        self._max_time_checkbox: QCheckBox = QCheckBox()
-        self._max_time_checkbox.setObjectName("timeoutCheckbox")
-        self._max_time_checkbox.stateChanged.connect(
-            self._max_time_checkbox_slot
-        )
-        max_time_layout.addWidget(self._max_time_checkbox)
-
-        max_time_left_text: QLabel = QLabel("Time out after")
-        max_time_layout.addWidget(max_time_left_text)
-
-        self._max_time_in_minutes_input: QLineEdit = QLineEdit()
-        self._max_time_in_minutes_input.setObjectName("timeoutMinuteInput")
-        self._max_time_in_minutes_input.setEnabled(False)
-        self._max_time_in_minutes_input.setMaximumWidth(30)
-        self._max_time_in_minutes_input.setPlaceholderText("30")
-        self._max_time_in_minutes_input.textChanged.connect(
-            lambda text: self._training_model.set_max_time(int(text))
-        )
-        max_time_layout.addWidget(self._max_time_in_minutes_input)
-
-        max_time_right_text: LabelWithHint = LabelWithHint("minutes")
-        max_time_right_text.set_hint("(Optional) Maximum time to train model")
-        max_time_layout.addWidget(
-            max_time_right_text, alignment=Qt.AlignmentFlag.AlignLeft
-        )
-        max_time_layout.addStretch()
-        bottom_grid_layout.addLayout(max_time_layout, 4, 1)
         bottom_grid_layout.setColumnStretch(1, 8)
         bottom_grid_layout.setColumnStretch(0, 3)
 


### PR DESCRIPTION
## Purpose
Seems like these no longer work- we will remove the timeout and cancel functionality. We can still specify a max number of epochs, which works.

Removing UI code but leaving everything else in case we'd like to fix and add it in the future.

**timeout** stopped working due to a cyto-dl change: looks like we need to specify max time in a different format. [ticket](https://github.com/AllenCell/allencell-segmenter-ml/issues/627)

**canceling a training run** doesnt work because QThread.terminate() cant guarantee the thread stops and doesnt release the python GIL cleanly and causes the entire app to freeze. it seems like cancelling training during different steps affects whether the thread terminates successfully or not (for example, if cancelled during setup or caching -> works fine, if cancelled mid epoch -> sometime freezes, sometimes doesnt-- which is why we previously may have thought it works fine
)
the best path forward seems to be to run the training task inside a separate process from within the thread. that process can be killed cleanly without freezing the app. we need to keep the QThread layer (rather than ditching QThread and just using a separate process) since we have signal/slot behavior (on error, on finish) expected by the UI and other parts of the app. [ticket
](https://github.com/AllenCell/allencell-segmenter-ml/issues/469#issuecomment-2895524115)
## Changes
Remove timeout and cancel functionality from UI

## Testing
Works on windows desktop, tests pass
