### PR TITLE
Bugfix/fix layers changed deprecation

### DIFF
--- a/.github/workflows/test_lint.yml
+++ b/.github/workflows/test_lint.yml
@@ -43,6 +43,12 @@ jobs:
       - name: Type check with mypy
         run: |
           mypy src/allencell_ml_segmenter
+      # This step ensures that opencv does not install libraries
+      # that may conflict with what is needed to run pyqt unit tests
+      - name: Force opencv-python-headless
+        run: |
+          pip uninstall -y opencv-python
+          pip install "numpy<2.0" opencv-python-headless
       - name: Test with pytest
         run: |
           pytest -v --color=yes --cov=allencell_ml_segmenter --cov-report=xml

--- a/.github/workflows/test_lint.yml
+++ b/.github/workflows/test_lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Force opencv-python-headless
         run: |
           pip uninstall -y opencv-python
-          pip install opencv-python-headless
+          pip install "numpy<2.0" opencv-python-headless
       - name: Test with pytest
         run: |
           pytest -v --color=yes --cov=allencell_ml_segmenter --cov-report=xml

--- a/.github/workflows/test_lint.yml
+++ b/.github/workflows/test_lint.yml
@@ -43,12 +43,6 @@ jobs:
       - name: Type check with mypy
         run: |
           mypy src/allencell_ml_segmenter
-      # This step ensures that opencv does not install libraries
-      # that may conflict with what is needed to run pyqt unit tests
-      - name: Force opencv-python-headless
-        run: |
-          pip uninstall -y opencv-python
-          pip install "numpy<2.0" opencv-python-headless
       - name: Test with pytest
         run: |
           pytest -v --color=yes --cov=allencell_ml_segmenter --cov-report=xml

--- a/.github/workflows/test_lint_pr.yaml
+++ b/.github/workflows/test_lint_pr.yaml
@@ -16,4 +16,4 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]

--- a/.github/workflows/test_lint_push.yml
+++ b/.github/workflows/test_lint_push.yml
@@ -14,4 +14,4 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]

--- a/docs/user_docs/conf.py
+++ b/docs/user_docs/conf.py
@@ -10,7 +10,7 @@
 project = "Segmenter ML Plugin for napari"
 copyright = "2024, Allen Institute for Cell Science"
 author = "Segmenter ML plugin team"
-release = "1.0.1"
+release = "1.0.1rc1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/user_docs/conf.py
+++ b/docs/user_docs/conf.py
@@ -10,7 +10,7 @@
 project = "Segmenter ML Plugin for napari"
 copyright = "2024, Allen Institute for Cell Science"
 author = "Segmenter ML plugin team"
-release = "1.0.1dev0"
+release = "1.0.1rc0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/user_docs/conf.py
+++ b/docs/user_docs/conf.py
@@ -10,7 +10,7 @@
 project = "Segmenter ML Plugin for napari"
 copyright = "2024, Allen Institute for Cell Science"
 author = "Segmenter ML plugin team"
-release = "1.0.1rc0"
+release = "1.0.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/user_docs/conf.py
+++ b/docs/user_docs/conf.py
@@ -10,7 +10,7 @@
 project = "Segmenter ML Plugin for napari"
 copyright = "2024, Allen Institute for Cell Science"
 author = "Segmenter ML plugin team"
-release = "1.0.0"
+release = "1.0.1dev0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 # https://peps.python.org/pep-0621/
 [project]
 name = "allencell-segmenter-ml"
-version = "1.0.1dev0"
+version = "1.0.1rc0"
 description = "A plugin to leverage ML segmentation in napari"
 readme = "README.md"
 requires-python = ">=3.9,<3.11"
@@ -118,7 +118,7 @@ where = ["src"]
 
 # https://pypi.org/project/bumpver
 [tool.bumpver]
-current_version = "1.0.1dev0"
+current_version = "1.0.1rc0"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 # https://peps.python.org/pep-0621/
 [project]
 name = "allencell-segmenter-ml"
-version = "1.0.1"
+version = "1.0.1rc1"
 description = "A plugin to leverage ML segmentation in napari"
 readme = "README.md"
 requires-python = ">=3.10,<3.11"
@@ -117,7 +117,7 @@ where = ["src"]
 
 # https://pypi.org/project/bumpver
 [tool.bumpver]
-current_version = "1.0.1"
+current_version = "1.0.1rc1"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies = [
     "npe2>=0.6.2",
-    "numpy",
+    "numpy>=1.24.2",
     "hydra-core==1.3.2",
     "bioio==1.1.0",
     "bioio-base==1.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "allencell-segmenter-ml"
 version = "1.0.1rc0"
 description = "A plugin to leverage ML segmentation in napari"
 readme = "README.md"
-requires-python = ">=3.9,<3.11"
+requires-python = ">=3.10,<3.11"
 license = { file = "LICENSE" }
 
 classifiers = [
@@ -24,7 +24,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 dependencies = [
     "npe2>=0.6.2",
     "numpy<2.0",
+    "opencv-python-headless",
     "hydra-core==1.3.2",
     "bioio==1.1.0",
     "bioio-base==1.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies = [
     "npe2>=0.6.2",
-    "numpy>=1.24.2",
+    "numpy<2.0",
     "hydra-core==1.3.2",
     "bioio==1.1.0",
     "bioio-base==1.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies = [
     "npe2>=0.6.2",
-    "numpy<2.0",
+    "numpy",
     "hydra-core==1.3.2",
     "bioio==1.1.0",
     "bioio-base==1.0.4",
@@ -51,7 +51,7 @@ Documentation = "https://github.com/AllenCell/allencell-ml-segmenter#README.md"
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
 napari = [
-    "napari>=0.4.18",
+    "napari>=0.6.2",
     "pyqt5",
 ]
 
@@ -67,7 +67,7 @@ test_lint = [
     "mypy",
     "toml",
     "bumpver",
-    "napari>=0.4.18",
+    "napari>=0.6.2",
     "magicgui"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 # https://peps.python.org/pep-0621/
 [project]
 name = "allencell-segmenter-ml"
-version = "1.0.1rc0"
+version = "1.0.1"
 description = "A plugin to leverage ML segmentation in napari"
 readme = "README.md"
 requires-python = ">=3.10,<3.11"
@@ -117,7 +117,7 @@ where = ["src"]
 
 # https://pypi.org/project/bumpver
 [tool.bumpver]
-current_version = "1.0.1rc0"
+current_version = "1.0.1"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
 dependencies = [
     "npe2>=0.6.2",
     "numpy<2.0",
-    "opencv-python-headless",
     "hydra-core==1.3.2",
     "bioio==1.1.0",
     "bioio-base==1.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 # https://peps.python.org/pep-0621/
 [project]
 name = "allencell-segmenter-ml"
-version = "1.0.0"
+version = "1.0.1dev0"
 description = "A plugin to leverage ML segmentation in napari"
 readme = "README.md"
 requires-python = ">=3.9,<3.11"
@@ -118,7 +118,7 @@ where = ["src"]
 
 # https://pypi.org/project/bumpver
 [tool.bumpver]
-current_version = "1.0.0"
+current_version = "1.0.1dev0"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 
 dependencies = [
     "npe2>=0.6.2",
-    "numpy",
+    "numpy<2.0",
     "hydra-core==1.3.2",
     "bioio==1.1.0",
     "bioio-base==1.0.4",

--- a/src/allencell_ml_segmenter/__init__.py
+++ b/src/allencell_ml_segmenter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1"
+__version__ = "1.0.1rc1"
 
 from allencell_ml_segmenter.napari.napari_reader import napari_get_reader
 from allencell_ml_segmenter.napari.sample_data import make_sample_data

--- a/src/allencell_ml_segmenter/__init__.py
+++ b/src/allencell_ml_segmenter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1dev0"
 
 from allencell_ml_segmenter.napari.napari_reader import napari_get_reader
 from allencell_ml_segmenter.napari.sample_data import make_sample_data

--- a/src/allencell_ml_segmenter/__init__.py
+++ b/src/allencell_ml_segmenter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1dev0"
+__version__ = "1.0.1rc0"
 
 from allencell_ml_segmenter.napari.napari_reader import napari_get_reader
 from allencell_ml_segmenter.napari.sample_data import make_sample_data

--- a/src/allencell_ml_segmenter/__init__.py
+++ b/src/allencell_ml_segmenter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1rc0"
+__version__ = "1.0.1"
 
 from allencell_ml_segmenter.napari.napari_reader import napari_get_reader
 from allencell_ml_segmenter.napari.sample_data import make_sample_data

--- a/src/allencell_ml_segmenter/_tests/main/test_main_widget.py
+++ b/src/allencell_ml_segmenter/_tests/main/test_main_widget.py
@@ -25,7 +25,16 @@ from napari.utils.events import EmitterGroup
 
 class FakeLayers:
     def __init__(self):
-        self.events = EmitterGroup(source=self, changed=None)
+        self.events = EmitterGroup(
+            source=self,
+            inserting=None,
+            inserted=None,
+            removing=None,
+            removed=None,
+            moving=None,
+            moved=None,
+            changed=None,
+        ) # all napari layer events
 
 
 @pytest.fixture

--- a/src/allencell_ml_segmenter/_tests/main/test_main_widget.py
+++ b/src/allencell_ml_segmenter/_tests/main/test_main_widget.py
@@ -34,7 +34,7 @@ class FakeLayers:
             moving=None,
             moved=None,
             changed=None,
-        ) # all napari layer events
+        )  # all napari layer events
 
 
 @pytest.fixture

--- a/src/allencell_ml_segmenter/_tests/main/test_main_widget.py
+++ b/src/allencell_ml_segmenter/_tests/main/test_main_widget.py
@@ -13,12 +13,19 @@ from allencell_ml_segmenter.core.aics_widget import AicsWidget
 from allencell_ml_segmenter.main.main_widget import MainWidget
 from unittest.mock import Mock, patch
 import napari
+from napari.utils.events import EmitterGroup
+
 
 # IMPORTANT NOTE: MainWidget is different from the other widgets since we do not directly
 # instantiate it in our code. So, it will always receive a napari.Viewer object in
 # production. We cannot initialize with our FakeViewer because our 'Viewer' is created during
 # initialization of MainWidget. We could supply a "viewer factory" to the MainWidget,
 # but for now I'm just mocking it here.
+
+
+class FakeLayers:
+    def __init__(self):
+        self.events = EmitterGroup(source=self, changed=None)
 
 
 @pytest.fixture
@@ -155,10 +162,14 @@ def test_experiments_home_initialized(qtbot: QtBot) -> None:
     settings.set_user_experiments_path(
         None
     )  # Simulates state where users has not yet chosen an experiments home.
+    viewer = Mock(
+        spec="napari.Viewer"
+    )  # set up fake viewer with layers that can emit events
+    viewer.layers = FakeLayers()
 
     # ACT
     MainWidget(
-        Mock(spec=napari.Viewer), settings
+        viewer, settings
     )  # If the users settings does not find an experiments home path, it will prompt the user for one and persist it.
 
     # ASSERT

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -128,7 +128,6 @@ class Viewer(IViewer):
         self.viewer.layers.events.removed.connect(function)
         self.viewer.layers.events.moved.connect(function)
 
-
     def _get_layer_by_name(self, name: str) -> Optional[Layer]:
         layers: list[Layer] = self.get_layers()
         for l in layers:

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -121,7 +121,7 @@ class Viewer(IViewer):
     def subscribe_layers_change_event(
         self, function: Callable[[NapariEvent], None]
     ) -> None:
-        self.viewer.events.layers_change.connect(function)
+        self.viewer.layers.events.changed.connect(function)
 
     def _get_layer_by_name(self, name: str) -> Optional[Layer]:
         layers: list[Layer] = self.get_layers()

--- a/src/allencell_ml_segmenter/main/viewer.py
+++ b/src/allencell_ml_segmenter/main/viewer.py
@@ -121,7 +121,13 @@ class Viewer(IViewer):
     def subscribe_layers_change_event(
         self, function: Callable[[NapariEvent], None]
     ) -> None:
+        # keeps layer list synced with the layer checkboxes in our plugin when
+        # items are added, removed, moved, or changed
         self.viewer.layers.events.changed.connect(function)
+        self.viewer.layers.events.inserted.connect(function)
+        self.viewer.layers.events.removed.connect(function)
+        self.viewer.layers.events.moved.connect(function)
+
 
     def _get_layer_by_name(self, name: str) -> Optional[Layer]:
         layers: list[Layer] = self.get_layers()


### PR DESCRIPTION
## Purpose
This fixes `layer_change` napari event being deprecated. 

Some background- we developed the plugin to respond to a napari `layer_change` event. Napari used to emit this event on any change to the layer list or any items inside napari's layer list, and we used this event to respond to sync our `FileInputWidget` up with the list of images available on the napari layer list. 

Now, napari seems to have gotten rid of the more general `layer_change` event for more fine grained events that fire based on different changes to the layer list.

The four events we need to be aware of are:
- `layers.events.inserted` (image added)
- `layers.events.removed` (image removed)
- `layers.events.moved` (layer reordered)
- `layers.events.changed` (an existing layer modified)

## Changes
I made the smallest change possible, which was directly replacing the `layer_change` event with the four events above that the plugin needs to be aware of when responding to changes in the layer list. 

A more ideal change would be to create dedicated handlers which respond to these changes individually, but this is a much bigger refactor. for now this keeps the plugin happy with the latest version of napari

Since we made this change, we can no longer use `layer_change` events and we have to drop support for all napari versions `< 0.6.2`, which means we need to drop python 3.9 support as well (since `napari==0.6.2` only supports python 3.10 and above)

## Testing
Tested by installing fresh on windows, and running a full curation -> training -> prediction -> thresholding run.

## How to review
Small change